### PR TITLE
Added single-line comments

### DIFF
--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -85,6 +85,14 @@
     ]
   }
 
+  # Matches single line comments
+  #
+  # // A single-line comment
+  {
+      'match': '^\/\/.*$'
+      'name': 'markup.block.asciidoc'
+  }
+
   # Matches example block
   #
   # Examples

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -89,7 +89,7 @@
   #
   # // A single-line comment
   {
-      'match': '^\/\/.*$'
+      'match': '^\/{2}\\p{Space}.*$'
       'name': 'markup.block.asciidoc'
   }
 

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -58,6 +58,11 @@ atom-text-editor, :host {
       color: @syntax-text-color-unobtrusive;
     }
 
+    .comment {
+      color: @syntax-text-color-unobtrusive;
+     // font-style: italic;
+    }
+
     .quote {
       color: mix(blue, @syntax-text-color, 20%);
     }


### PR DESCRIPTION
This is just a quick fix, I am not that familiar with Atom internals.

* Added a match for single-line comments
* Created `.comment` style that applies to all comments (block and single-line)