### PR TITLE
fix: italic highlight with underscores

### DIFF
--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -297,7 +297,7 @@
   'inline':
     'patterns': [
 
-      # Matches bold pharses
+      # Matches bold constrained phrases
       #
       # Examples
       #
@@ -308,13 +308,24 @@
           '0': 'name': 'markup.bold.asciidoc'
       }
 
-      # Matches italic pharses
+      # Matches italic constrained phrases
       #
       # Examples
       #
       #   _italic phrase_
       {
-        'match': '(?<=^|\\s)(_[^_^\\s].*?_)(?=\\s|$)'
+        'match': '(?!_{4,}\\s*$)(?<=^|[^\\w;:])(?:\\[(?:[^\\]]+?)\\])?(_\\S_|_\\S[\\s\\S]*?\\S_)(?!\\w)'
+        'captures':
+          '0': 'name': 'markup.italic.asciidoc'
+      }
+
+      # Matches italic unconstrained phrases
+      #
+      # Examples
+      #
+      #   i__talic__ phrase
+      {
+        'match': '\\\\?(?:\\[([^\\]]+?)\\])?(__(?!_)[\\s\\S]+?__)' # now including the underscores in the match
         'captures':
           '0': 'name': 'markup.italic.asciidoc'
       }

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -314,7 +314,7 @@
       #
       #   _italic phrase_
       {
-        'match': '(?<=^|\\s)(_[^_]+_)'
+        'match': '(?<=^|\\s)(_[^_^\\s].*?_)(?=\\s|$)'
         'captures':
           '0': 'name': 'markup.italic.asciidoc'
       }

--- a/spec/asciidoc-spec.coffee
+++ b/spec/asciidoc-spec.coffee
@@ -28,6 +28,12 @@ describe "AsciiDoc grammar", ->
     expect(tokens[1]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
     expect(tokens[2]).toEqual value: " text", scopes: ["source.asciidoc"]
 
+  it "tokenizes _italic_ text with underscores", ->
+    {tokens} = grammar.tokenizeLine("this is _italic_text_ with underscores")
+    expect(tokens[0]).toEqual value: "this is ", scopes: ["source.asciidoc"]
+    expect(tokens[1]).toEqual value: "_italic_text_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[2]).toEqual value: " with underscores", scopes: ["source.asciidoc"]
+
   it "tokenizes HTML elements", ->
     {tokens} = grammar.tokenizeLine("Dungeons &amp; Dragons")
     expect(tokens[0]).toEqual value: "Dungeons ", scopes: ["source.asciidoc"]

--- a/spec/asciidoc-spec.coffee
+++ b/spec/asciidoc-spec.coffee
@@ -28,11 +28,82 @@ describe "AsciiDoc grammar", ->
     expect(tokens[1]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
     expect(tokens[2]).toEqual value: " text", scopes: ["source.asciidoc"]
 
+  it "tokenizes unconstrained __italic__ text", ->
+    {tokens} = grammar.tokenizeLine("this is__italic__text")
+    expect(tokens[0]).toEqual value: "this is", scopes: ["source.asciidoc"]
+    expect(tokens[1]).toEqual value: "__italic__", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[2]).toEqual value: "text", scopes: ["source.asciidoc"]
+
   it "tokenizes _italic_ text with underscores", ->
     {tokens} = grammar.tokenizeLine("this is _italic_text_ with underscores")
     expect(tokens[0]).toEqual value: "this is ", scopes: ["source.asciidoc"]
     expect(tokens[1]).toEqual value: "_italic_text_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
     expect(tokens[2]).toEqual value: " with underscores", scopes: ["source.asciidoc"]
+
+  it "tokenizes multi-line constrained _italic_ text", ->
+    {tokens} = grammar.tokenizeLine("""
+                                    this is _multi- 
+                                    line italic_ text
+                                    """)
+    expect(tokens[0]).toEqual value: "this is ", scopes: ["source.asciidoc"]
+    expect(tokens[1]).toEqual value: """
+                                    _multi- 
+                                    line italic_
+                                    """, scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[2]).toEqual value: " text", scopes: ["source.asciidoc"]
+
+  it "tokenizes multi-line unconstrained _italic_ text", ->
+    {tokens} = grammar.tokenizeLine("""
+                                    this is__multi- 
+                                    line italic__text
+                                    """)
+    expect(tokens[0]).toEqual value: "this is", scopes: ["source.asciidoc"]
+    expect(tokens[1]).toEqual value: """
+                                    __multi- 
+                                    line italic__
+                                    """, scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[2]).toEqual value: "text", scopes: ["source.asciidoc"]
+
+  it "tokenizes _italic_ text at the beginning of the line", ->
+    {tokens} = grammar.tokenizeLine("_italic text_ from the start.")
+    expect(tokens[0]).toEqual value: "_italic text_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[1]).toEqual value: " from the start.", scopes: ["source.asciidoc"]
+
+  it "tokenizes _italic_ text in a * bulleted list", ->
+    {tokens} = grammar.tokenizeLine("* _italic text_ followed by normal text")
+    expect(tokens[0]).toEqual value: "*", scopes: ["source.asciidoc", "markup.list.asciidoc", "markup.list.bullet.asciidoc"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.asciidoc", "markup.list.asciidoc"]
+    expect(tokens[2]).toEqual value: "_italic text_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[3]).toEqual value: " followed by normal text", scopes: ["source.asciidoc"]
+
+  it "tokenizes constrained _italic_ text within special characters", ->
+    {tokens} = grammar.tokenizeLine("a_non-italic_a, !_italic_?, '_italic_:, ._italic_; ,_italic_")
+    expect(tokens[0]).toEqual value: "a_non-italic_a, !", scopes: ["source.asciidoc"]
+    expect(tokens[1]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[2]).toEqual value: "?, '", scopes: ["source.asciidoc"]
+    expect(tokens[3]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[4]).toEqual value: ":, .", scopes: ["source.asciidoc"]
+    expect(tokens[5]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[6]).toEqual value: "; ,", scopes: ["source.asciidoc"]
+    expect(tokens[7]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+
+  it "tokenizes variants of unbalanced underscores around _italic_ text", ->
+    {tokens} = grammar.tokenizeLine("_italic_ __italic_ ___italic_ ___italic__ ___italic___ __italic___ _italic___ _italic__")
+    expect(tokens[0]).toEqual value: "_italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[2]).toEqual value: "__italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[4]).toEqual value: "___italic_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[5]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[6]).toEqual value: "___italic__", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[7]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[8]).toEqual value: "___italic___", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[9]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[10]).toEqual value: "__italic___", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[11]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[12]).toEqual value: "_italic___", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[13]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[14]).toEqual value: "_italic__", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
 
   it "tokenizes HTML elements", ->
     {tokens} = grammar.tokenizeLine("Dungeons &amp; Dragons")


### PR DESCRIPTION
Using a lazy quantifier and a lookahead to ensure
that the highlight will break at the first
underscore followed by a space or line end.

Fixes issue #21.