### PR TITLE
feat: add CoffeeLint as dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,25 @@
-language: objective-c
-
 notifications:
   email:
     on_success: never
     on_failure: change
 
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
+  },
+  "devDependencies": {
+    "coffeelint": "^1.15.0"
   }
 }

--- a/spec/asciidoc-spec.coffee
+++ b/spec/asciidoc-spec.coffee
@@ -42,24 +42,24 @@ describe "AsciiDoc grammar", ->
 
   it "tokenizes multi-line constrained _italic_ text", ->
     {tokens} = grammar.tokenizeLine("""
-                                    this is _multi- 
+                                    this is _multi-
                                     line italic_ text
                                     """)
     expect(tokens[0]).toEqual value: "this is ", scopes: ["source.asciidoc"]
     expect(tokens[1]).toEqual value: """
-                                    _multi- 
+                                    _multi-
                                     line italic_
                                     """, scopes: ["source.asciidoc", "markup.italic.asciidoc"]
     expect(tokens[2]).toEqual value: " text", scopes: ["source.asciidoc"]
 
   it "tokenizes multi-line unconstrained _italic_ text", ->
     {tokens} = grammar.tokenizeLine("""
-                                    this is__multi- 
+                                    this is__multi-
                                     line italic__text
                                     """)
     expect(tokens[0]).toEqual value: "this is", scopes: ["source.asciidoc"]
     expect(tokens[1]).toEqual value: """
-                                    __multi- 
+                                    __multi-
                                     line italic__
                                     """, scopes: ["source.asciidoc", "markup.italic.asciidoc"]
     expect(tokens[2]).toEqual value: "text", scopes: ["source.asciidoc"]


### PR DESCRIPTION
- useful for Travis CI

Related to #32

Build script (https://raw.githubusercontent.com/atom/ci/master/build-package.sh) have a special section for run automatically CoffeeLint if is present.

```bash
if [ -f ./node_modules/.bin/coffeelint ]; then
  if [ -d ./lib ]; then
    echo "Linting package..."
    ./node_modules/.bin/coffeelint lib
    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
  fi
  if [ -d ./spec ]; then
    echo "Linting package specs..."
    ./node_modules/.bin/coffeelint spec
    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
  fi
fi
```