### PR TITLE
refactor: code block scope

### DIFF
--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -765,7 +765,7 @@
         ]
       }
 
-      # Matches SASS AsciiDoc code blocks
+      # Matches SCSS AsciiDoc code blocks
       #
       # Examples
       #
@@ -774,7 +774,7 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(scss|sass))\\]$'
+        'begin': '^\\[source,\\s*(?i:(scss))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
@@ -789,6 +789,34 @@
             'name': 'markup.code.css.scss.asciidoc'
             'contentName': 'source.embedded.css.scss'
             'patterns': ['include': 'source.css.scss']
+          }
+        ]
+      }
+
+      # Matches SASS AsciiDoc code blocks
+      #
+      # Examples
+      #
+      #   [source,sass]
+      #   ----
+      #  ...
+      #   ----
+      {
+        'begin': '^\\[source,\\s*(?i:(sass))\\]$'
+        'beginCaptures':
+          '0': 'name': 'support.asciidoc'
+        'end': '(?<=----)[\\r\\n]+$'
+        'patterns': [
+          {
+            'begin': '^(-{4,})\\s*$'
+            'beginCaptures':
+              '0': 'name': 'support.asciidoc'
+            'end': '^\\1*$'
+            'endCaptures':
+              '0': 'name': 'support.asciidoc'
+            'name': 'markup.code.sass.asciidoc'
+            'contentName': 'source.embedded.sass'
+            'patterns': ['include': 'source.sass']
           }
         ]
       }
@@ -1774,7 +1802,7 @@
         'patterns': ['include': 'source.css.less']
       }
 
-      # Matches SASS Markdown-style code blocks
+      # Matches SCSS Markdown-style code blocks
       #
       # Examples
       #
@@ -1782,15 +1810,34 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(scss|sass))\\s*$'
+        'begin': '^\\s*(`{3,})\\s*(?i:(scss))\\s*$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '^\\s*\\1\\s*$'
         'endCaptures':
           '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.scss.less.asciidoc'
+        'name': 'markup.code.css.scss.asciidoc'
         'contentName': 'source.embedded.css.scss'
         'patterns': ['include': 'source.css.scss']
+      }
+
+      # Matches SASS Markdown-style code blocks
+      #
+      # Examples
+      #
+      #   ```sass
+      #   ...
+      #   ```
+      {
+        'begin': '^\\s*(`{3,})\\s*(?i:(sass))\\s*$'
+        'beginCaptures':
+          '0': 'name': 'support.asciidoc'
+        'end': '^\\s*\\1\\s*$'
+        'endCaptures':
+          '0': 'name': 'support.asciidoc'
+        'name': 'markup.code.sass.asciidoc'
+        'contentName': 'source.embedded.sass'
+        'patterns': ['include': 'source.sass']
       }
 
       # Matches XML Markdown-style code blocks

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -465,10 +465,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(javascript|js))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -497,10 +497,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(ruby|rb))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -525,10 +525,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(go(lang)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -553,10 +553,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(java))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -581,10 +581,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(markdown|mdown|md))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -609,10 +609,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(ya?ml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -637,10 +637,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(coffee-?(script)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -665,10 +665,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(json))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -693,10 +693,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(css))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -721,10 +721,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(less))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -749,10 +749,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(scss|sass))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -777,10 +777,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(xml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -805,10 +805,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(rust|rs))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -833,10 +833,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(docker(file)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -861,10 +861,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(properties))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -889,10 +889,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(make(file)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -917,10 +917,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(perl))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -945,10 +945,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(perl6))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -973,10 +973,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(toml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1001,10 +1001,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(erlang))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1029,10 +1029,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(cs(harp)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1057,10 +1057,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(php))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1085,10 +1085,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(sh|bash|shell))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1113,10 +1113,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(py(thon)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1141,10 +1141,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(c))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1169,10 +1169,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1197,10 +1197,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(objc|objective-c))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1225,10 +1225,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(swift))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1253,10 +1253,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(html))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1281,10 +1281,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(elixir))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1309,10 +1309,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(diff|patch|rej))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1337,10 +1337,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(julia))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1365,10 +1365,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(r))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1393,10 +1393,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(haskell))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1421,10 +1421,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(elm))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1449,10 +1449,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(sql))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1477,10 +1477,10 @@
         'begin': '^\\s*\\[source,\\s*(?i:(clojure))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'
@@ -1509,10 +1509,10 @@
         'begin': '^\\s*\\[source(,[^\\],]*)?\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
-        'end': '^\\s*$'
+        'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '(^\\s*-{4,}\\s*$)'
+            'begin': '^\\s*(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
             'end': '^\\s*\\1*$'

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -926,9 +926,9 @@
             'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.git-config.asciidoc'
-            'contentName': 'source.embedded.git-config'
-            'patterns': ['include': 'source.git-config']
+            'name': 'markup.code.properties.asciidoc'
+            'contentName': 'source.embedded.asciidoc.properties'
+            'patterns': ['include': 'source.asciidoc.properties']
           }
         ]
       }
@@ -1911,9 +1911,9 @@
         'end': '^\\s*\\1\\s*$'
         'endCaptures':
           '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.git-config.asciidoc'
-        'contentName': 'source.embedded.git-config'
-        'patterns': ['include': 'source.git-config']
+        'name': 'markup.code.properties.asciidoc'
+        'contentName': 'source.embedded.asciidoc.properties'
+        'patterns': ['include': 'source.asciidoc.properties']
       }
 
       # Matches Makefile Markdown-style code blocks

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -653,6 +653,34 @@
         ]
       }
 
+      # Matches TypeScript AsciiDoc code blocks
+      #
+      # Examples
+      #
+      #   [source,ts]
+      #   ----
+      #  ...
+      #   ----
+      {
+        'begin': '^\\[source,\\s*(?i:(typescript|ts))\\]$'
+        'beginCaptures':
+          '0': 'name': 'support.asciidoc'
+        'end': '(?<=----)[\\r\\n]+$'
+        'patterns': [
+          {
+            'begin': '^(-{4,})\\s*$'
+            'beginCaptures':
+              '0': 'name': 'support.asciidoc'
+            'end': '^\\1*$'
+            'endCaptures':
+              '0': 'name': 'support.asciidoc'
+            'name': 'markup.code.ts.asciidoc'
+            'contentName': 'source.embedded.ts'
+            'patterns': ['include': 'source.ts']
+          }
+        ]
+      }
+
       # Matches JSON AsciiDoc code blocks
       #
       # Examples
@@ -1668,6 +1696,25 @@
         'name': 'markup.code.coffee.asciidoc'
         'contentName': 'source.embedded.coffee'
         'patterns': ['include': 'source.coffee']
+      }
+
+      # Matches TypeScript Markdown-style code blocks
+      #
+      # Examples
+      #
+      #   ```ts
+      #   ...
+      #   ```
+      {
+        'begin': '^\\s*(`{3,})\\s*(?i:(typescript|ts))\\s*$'
+        'beginCaptures':
+          '0': 'name': 'support.asciidoc'
+        'end': '^\\s*\\1\\s*$'
+        'endCaptures':
+          '0': 'name': 'support.asciidoc'
+        'name': 'markup.code.ts.asciidoc'
+        'contentName': 'source.embedded.ts'
+        'patterns': ['include': 'source.ts']
       }
 
       # Matches JSON Markdown-style code blocks

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -1,23 +1,23 @@
-'name': 'AsciiDoc'
-'scopeName': 'source.asciidoc'
-'fileTypes': [
+name: 'AsciiDoc'
+scopeName: 'source.asciidoc'
+fileTypes: [
   'ad'
   'asc'
   'adoc'
   'asciidoc'
 ]
 
-'patterns': [
+patterns: [
 
   # Includes inline patterns, see repository section below.
   {
-    'include': '#inline'
+    include: '#inline'
   }
 
   # Includes AsciiDoc and Markdown style code blocks, see repository section
   # below.
   {
-    'include': '#codeBlocks'
+    include: '#codeBlocks'
   }
 
   # Matches section titles (headers)
@@ -462,21 +462,21 @@
       #   }).listen(1337, '127.0.0.1');
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(javascript|js))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(javascript|js))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.js.asciidoc'
-            'contentName': 'source.embedded.js'
-            'patterns': ['include': 'source.js']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.js.asciidoc'
+            contentName: 'source.embedded.js'
+            patterns: [include: 'source.js']
           }
         ]
       }
@@ -494,21 +494,21 @@
       #   end
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(ruby|rb))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(ruby|rb))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.ruby.asciidoc'
-            'contentName': 'source.embedded.ruby'
-            'patterns': ['include': 'source.ruby']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.ruby.asciidoc'
+            contentName: 'source.embedded.ruby'
+            patterns: [include: 'source.ruby']
           }
         ]
       }
@@ -522,21 +522,21 @@
       #   ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(go(lang)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(go(lang)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.go.asciidoc'
-            'contentName': 'source.embedded.go'
-            'patterns': ['include': 'source.go']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.go.asciidoc'
+            contentName: 'source.embedded.go'
+            patterns: [include: 'source.go']
           }
         ]
       }
@@ -550,21 +550,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(java))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(java))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.java.asciidoc'
-            'contentName': 'source.embedded.java'
-            'patterns': ['include': 'source.java']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.java.asciidoc'
+            contentName: 'source.embedded.java'
+            patterns: [include: 'source.java']
           }
         ]
       }
@@ -578,21 +578,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(markdown|mdown|md))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(markdown|mdown|md))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.gfm.asciidoc'
-            'contentName': 'source.embedded.gfm'
-            'patterns': ['include': 'source.gfm']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.gfm.asciidoc'
+            contentName: 'source.embedded.gfm'
+            patterns: [include: 'source.gfm']
           }
         ]
       }
@@ -606,21 +606,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(ya?ml))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(ya?ml))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.yaml.asciidoc'
-            'contentName': 'source.embedded.yaml'
-            'patterns': ['include': 'source.yaml']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.yaml.asciidoc'
+            contentName: 'source.embedded.yaml'
+            patterns: [include: 'source.yaml']
           }
         ]
       }
@@ -634,21 +634,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(coffee-?(script)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(coffee-?(script)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.coffee.asciidoc'
-            'contentName': 'source.embedded.coffee'
-            'patterns': ['include': 'source.coffee']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.coffee.asciidoc'
+            contentName: 'source.embedded.coffee'
+            patterns: [include: 'source.coffee']
           }
         ]
       }
@@ -662,21 +662,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(typescript|ts))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(typescript|ts))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.ts.asciidoc'
-            'contentName': 'source.embedded.ts'
-            'patterns': ['include': 'source.ts']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.ts.asciidoc'
+            contentName: 'source.embedded.ts'
+            patterns: [include: 'source.ts']
           }
         ]
       }
@@ -690,21 +690,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(json))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(json))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.json.asciidoc'
-            'contentName': 'source.embedded.json'
-            'patterns': ['include': 'source.json']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.json.asciidoc'
+            contentName: 'source.embedded.json'
+            patterns: [include: 'source.json']
           }
         ]
       }
@@ -718,21 +718,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(css))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(css))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.css.asciidoc'
-            'contentName': 'source.embedded.css'
-            'patterns': ['include': 'source.css']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.css.asciidoc'
+            contentName: 'source.embedded.css'
+            patterns: [include: 'source.css']
           }
         ]
       }
@@ -746,21 +746,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(less))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(less))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.css.less.asciidoc'
-            'contentName': 'source.embedded.css.less'
-            'patterns': ['include': 'source.css.less']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.css.less.asciidoc'
+            contentName: 'source.embedded.css.less'
+            patterns: [include: 'source.css.less']
           }
         ]
       }
@@ -774,21 +774,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(scss))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(scss))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.css.scss.asciidoc'
-            'contentName': 'source.embedded.css.scss'
-            'patterns': ['include': 'source.css.scss']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.css.scss.asciidoc'
+            contentName: 'source.embedded.css.scss'
+            patterns: [include: 'source.css.scss']
           }
         ]
       }
@@ -802,21 +802,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(sass))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(sass))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.sass.asciidoc'
-            'contentName': 'source.embedded.sass'
-            'patterns': ['include': 'source.sass']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.sass.asciidoc'
+            contentName: 'source.embedded.sass'
+            patterns: [include: 'source.sass']
           }
         ]
       }
@@ -830,21 +830,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(xml))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(xml))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.xml.asciidoc'
-            'contentName': 'text.embedded.xml'
-            'patterns': ['include': 'text.xml']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.xml.asciidoc'
+            contentName: 'text.embedded.xml'
+            patterns: [include: 'text.xml']
           }
         ]
       }
@@ -858,21 +858,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(rust|rs))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(rust|rs))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.rust.asciidoc'
-            'contentName': 'source.embedded.rust'
-            'patterns': ['include': 'source.rust']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.rust.asciidoc'
+            contentName: 'source.embedded.rust'
+            patterns: [include: 'source.rust']
           }
         ]
       }
@@ -886,21 +886,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(docker(file)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(docker(file)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.dockerfile.asciidoc'
-            'contentName': 'source.embedded.dockerfile'
-            'patterns': ['include': 'source.dockerfile']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.dockerfile.asciidoc'
+            contentName: 'source.embedded.dockerfile'
+            patterns: [include: 'source.dockerfile']
           }
         ]
       }
@@ -914,21 +914,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(properties))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(properties))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.properties.asciidoc'
-            'contentName': 'source.embedded.asciidoc.properties'
-            'patterns': ['include': 'source.asciidoc.properties']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.properties.asciidoc'
+            contentName: 'source.embedded.asciidoc.properties'
+            patterns: [include: 'source.asciidoc.properties']
           }
         ]
       }
@@ -942,21 +942,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(make(file)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(make(file)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.makefile.asciidoc'
-            'contentName': 'source.embedded.makefile'
-            'patterns': ['include': 'source.makefile']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.makefile.asciidoc'
+            contentName: 'source.embedded.makefile'
+            patterns: [include: 'source.makefile']
           }
         ]
       }
@@ -970,21 +970,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(perl))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(perl))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.perl.asciidoc'
-            'contentName': 'source.embedded.perl'
-            'patterns': ['include': 'source.perl']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.perl.asciidoc'
+            contentName: 'source.embedded.perl'
+            patterns: [include: 'source.perl']
           }
         ]
       }
@@ -998,21 +998,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(perl6))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(perl6))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.perl6.asciidoc'
-            'contentName': 'source.embedded.perl6'
-            'patterns': ['include': 'source.perl6']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.perl6.asciidoc'
+            contentName: 'source.embedded.perl6'
+            patterns: [include: 'source.perl6']
           }
         ]
       }
@@ -1026,21 +1026,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(toml))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(toml))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.toml.asciidoc'
-            'contentName': 'source.embedded.toml'
-            'patterns': ['include': 'source.toml']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.toml.asciidoc'
+            contentName: 'source.embedded.toml'
+            patterns: [include: 'source.toml']
           }
         ]
       }
@@ -1054,21 +1054,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(erlang))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(erlang))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.erlang.asciidoc'
-            'contentName': 'source.embedded.erlang'
-            'patterns': ['include': 'source.erlang']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.erlang.asciidoc'
+            contentName: 'source.embedded.erlang'
+            patterns: [include: 'source.erlang']
           }
         ]
       }
@@ -1082,21 +1082,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(cs(harp)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(cs(harp)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.cs.asciidoc'
-            'contentName': 'source.embedded.cs'
-            'patterns': ['include': 'source.cs']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.cs.asciidoc'
+            contentName: 'source.embedded.cs'
+            patterns: [include: 'source.cs']
           }
         ]
       }
@@ -1110,21 +1110,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(php))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(php))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.php.asciidoc'
-            'contentName': 'text.embedded.html.php'
-            'patterns': ['include': 'text.html.php']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.php.asciidoc'
+            contentName: 'text.embedded.html.php'
+            patterns: [include: 'text.html.php']
           }
         ]
       }
@@ -1138,21 +1138,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(sh|bash|shell))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(sh|bash|shell))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.shell.asciidoc'
-            'contentName': 'source.embedded.shell'
-            'patterns': ['include': 'source.shell']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.shell.asciidoc'
+            contentName: 'source.embedded.shell'
+            patterns: [include: 'source.shell']
           }
         ]
       }
@@ -1166,21 +1166,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(py(thon)?))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(py(thon)?))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.python.asciidoc'
-            'contentName': 'source.embedded.python'
-            'patterns': ['include': 'source.python']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.python.asciidoc'
+            contentName: 'source.embedded.python'
+            patterns: [include: 'source.python']
           }
         ]
       }
@@ -1194,21 +1194,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(c))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(c))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.c.asciidoc'
-            'contentName': 'source.embedded.c'
-            'patterns': ['include': 'source.c']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.c.asciidoc'
+            contentName: 'source.embedded.c'
+            patterns: [include: 'source.c']
           }
         ]
       }
@@ -1222,21 +1222,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.cpp.asciidoc'
-            'contentName': 'source.embedded.cpp'
-            'patterns': ['include': 'source.cpp']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.cpp.asciidoc'
+            contentName: 'source.embedded.cpp'
+            patterns: [include: 'source.cpp']
           }
         ]
       }
@@ -1250,21 +1250,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(objc|objective-c))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(objc|objective-c))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.objc.asciidoc'
-            'contentName': 'source.embedded.objc'
-            'patterns': ['include': 'source.objc']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.objc.asciidoc'
+            contentName: 'source.embedded.objc'
+            patterns: [include: 'source.objc']
           }
         ]
       }
@@ -1278,21 +1278,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(swift))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(swift))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.swift.asciidoc'
-            'contentName': 'source.embedded.swift'
-            'patterns': ['include': 'source.swift']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.swift.asciidoc'
+            contentName: 'source.embedded.swift'
+            patterns: [include: 'source.swift']
           }
         ]
       }
@@ -1306,21 +1306,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(html))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(html))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.html.asciidoc'
-            'contentName': 'text.embedded.html.basic'
-            'patterns': ['include': 'text.html.basic']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.html.asciidoc'
+            contentName: 'text.embedded.html.basic'
+            patterns: [include: 'text.html.basic']
           }
         ]
       }
@@ -1334,21 +1334,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(elixir))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(elixir))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.elixir.asciidoc'
-            'contentName': 'source.embedded.elixir'
-            'patterns': ['include': 'source.elixir']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.elixir.asciidoc'
+            contentName: 'source.embedded.elixir'
+            patterns: [include: 'source.elixir']
           }
         ]
       }
@@ -1362,21 +1362,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(diff|patch|rej))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(diff|patch|rej))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.diff.asciidoc'
-            'contentName': 'source.embedded.diff'
-            'patterns': ['include': 'source.diff']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.diff.asciidoc'
+            contentName: 'source.embedded.diff'
+            patterns: [include: 'source.diff']
           }
         ]
       }
@@ -1390,21 +1390,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(julia))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(julia))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.julia.asciidoc'
-            'contentName': 'source.embedded.julia'
-            'patterns': ['include': 'source.julia']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.julia.asciidoc'
+            contentName: 'source.embedded.julia'
+            patterns: [include: 'source.julia']
           }
         ]
       }
@@ -1418,21 +1418,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(r))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(r))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.r.asciidoc'
-            'contentName': 'source.embedded.r'
-            'patterns': ['include': 'source.r']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.r.asciidoc'
+            contentName: 'source.embedded.r'
+            patterns: [include: 'source.r']
           }
         ]
       }
@@ -1446,21 +1446,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(haskell))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(haskell))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.haskell.asciidoc'
-            'contentName': 'source.embedded.haskell'
-            'patterns': ['include': 'source.haskell']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.haskell.asciidoc'
+            contentName: 'source.embedded.haskell'
+            patterns: [include: 'source.haskell']
           }
         ]
       }
@@ -1474,21 +1474,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(elm))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(elm))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.elm.asciidoc'
-            'contentName': 'source.embedded.elm'
-            'patterns': ['include': 'source.elm']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.elm.asciidoc'
+            contentName: 'source.embedded.elm'
+            patterns: [include: 'source.elm']
           }
         ]
       }
@@ -1502,21 +1502,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(sql))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(sql))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.sql.asciidoc'
-            'contentName': 'source.embedded.sql'
-            'patterns': ['include': 'source.sql']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.sql.asciidoc'
+            contentName: 'source.embedded.sql'
+            patterns: [include: 'source.sql']
           }
         ]
       }
@@ -1530,21 +1530,21 @@
       #  ...
       #   ----
       {
-        'begin': '^\\[source,\\s*(?i:(clojure))\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\[source,\\s*(?i:(clojure))\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.code.clojure.asciidoc'
-            'contentName': 'source.embedded.clojure'
-            'patterns': ['include': 'source.clojure']
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.code.clojure.asciidoc'
+            contentName: 'source.embedded.clojure'
+            patterns: [include: 'source.clojure']
           }
         ]
       }
@@ -1562,19 +1562,19 @@
       #   end
       #   ----
       {
-        'begin': '^\\s*\\[source(,[^\\],]*)?\\]$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '(?<=----)[\\r\\n]+$'
-        'patterns': [
+        begin: '^\\s*\\[source(,[^\\],]*)?\\]$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '(?<=----)[\\r\\n]+$'
+        patterns: [
           {
-            'begin': '^(-{4,})\\s*$'
-            'beginCaptures':
-              '0': 'name': 'support.asciidoc'
-            'end': '^\\1*$'
-            'endCaptures':
-              '0': 'name': 'support.asciidoc'
-            'name': 'markup.raw.asciidoc'
+            begin: '^(-{4,})\\s*$'
+            beginCaptures:
+              0: name: 'support.asciidoc'
+            end: '^\\1*$'
+            endCaptures:
+              0: name: 'support.asciidoc'
+            name: 'markup.raw.asciidoc'
           }
         ]
       }
@@ -1597,15 +1597,15 @@
       #   }).listen(1337, '127.0.0.1');
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(javascript|js))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.js.asciidoc'
-        'contentName': 'source.embedded.js'
-        'patterns': ['include': 'source.js']
+        begin: '^\\s*(`{3,})\\s*(?i:(javascript|js))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.js.asciidoc'
+        contentName: 'source.embedded.js'
+        patterns: [include: 'source.js']
       }
 
       # Matches Ruby Markdown-style code blocks
@@ -1620,15 +1620,15 @@
       #   end
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(ruby|rb))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.ruby.asciidoc'
-        'contentName': 'source.embedded.ruby'
-        'patterns': ['include': 'source.ruby']
+        begin: '^\\s*(`{3,})\\s*(?i:(ruby|rb))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.ruby.asciidoc'
+        contentName: 'source.embedded.ruby'
+        patterns: [include: 'source.ruby']
       }
 
       # Matches Go Markdown-style code blocks
@@ -1639,15 +1639,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(go(lang)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.go.asciidoc'
-        'contentName': 'source.embedded.go'
-        'patterns': ['include': 'source.go']
+        begin: '^\\s*(`{3,})\\s*(?i:(go(lang)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.go.asciidoc'
+        contentName: 'source.embedded.go'
+        patterns: [include: 'source.go']
       }
 
       # Matches Java Markdown-style code blocks
@@ -1658,15 +1658,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(java))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.java.asciidoc'
-        'contentName': 'source.embedded.java'
-        'patterns': ['include': 'source.java']
+        begin: '^\\s*(`{3,})\\s*(?i:(java))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.java.asciidoc'
+        contentName: 'source.embedded.java'
+        patterns: [include: 'source.java']
       }
 
       # Matches Makdown Markdown-style code blocks
@@ -1677,15 +1677,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.gfm.asciidoc'
-        'contentName': 'source.embedded.gfm'
-        'patterns': ['include': 'source.gfm']
+        begin: '^\\s*(`{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.gfm.asciidoc'
+        contentName: 'source.embedded.gfm'
+        patterns: [include: 'source.gfm']
       }
 
       # Matches YAML Markdown-style code blocks
@@ -1696,15 +1696,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(ya?ml))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.yaml.asciidoc'
-        'contentName': 'source.embedded.yaml'
-        'patterns': ['include': 'source.yaml']
+        begin: '^\\s*(`{3,})\\s*(?i:(ya?ml))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.yaml.asciidoc'
+        contentName: 'source.embedded.yaml'
+        patterns: [include: 'source.yaml']
       }
 
       # Matches CoffeScript Markdown-style code blocks
@@ -1715,15 +1715,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(coffee-?(script)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.coffee.asciidoc'
-        'contentName': 'source.embedded.coffee'
-        'patterns': ['include': 'source.coffee']
+        begin: '^\\s*(`{3,})\\s*(?i:(coffee-?(script)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.coffee.asciidoc'
+        contentName: 'source.embedded.coffee'
+        patterns: [include: 'source.coffee']
       }
 
       # Matches TypeScript Markdown-style code blocks
@@ -1734,15 +1734,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(typescript|ts))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.ts.asciidoc'
-        'contentName': 'source.embedded.ts'
-        'patterns': ['include': 'source.ts']
+        begin: '^\\s*(`{3,})\\s*(?i:(typescript|ts))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.ts.asciidoc'
+        contentName: 'source.embedded.ts'
+        patterns: [include: 'source.ts']
       }
 
       # Matches JSON Markdown-style code blocks
@@ -1753,15 +1753,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(json))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.json.asciidoc'
-        'contentName': 'source.embedded.json'
-        'patterns': ['include': 'source.json']
+        begin: '^\\s*(`{3,})\\s*(?i:(json))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.json.asciidoc'
+        contentName: 'source.embedded.json'
+        patterns: [include: 'source.json']
       }
 
       # Matches CSS Markdown-style code blocks
@@ -1772,15 +1772,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(css))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.css.asciidoc'
-        'contentName': 'source.embedded.css'
-        'patterns': ['include': 'source.css']
+        begin: '^\\s*(`{3,})\\s*(?i:(css))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.css.asciidoc'
+        contentName: 'source.embedded.css'
+        patterns: [include: 'source.css']
       }
 
       # Matches LESS Markdown-style code blocks
@@ -1791,15 +1791,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(less))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.css.less.asciidoc'
-        'contentName': 'source.embedded.css.less'
-        'patterns': ['include': 'source.css.less']
+        begin: '^\\s*(`{3,})\\s*(?i:(less))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.css.less.asciidoc'
+        contentName: 'source.embedded.css.less'
+        patterns: [include: 'source.css.less']
       }
 
       # Matches SCSS Markdown-style code blocks
@@ -1810,15 +1810,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(scss))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.css.scss.asciidoc'
-        'contentName': 'source.embedded.css.scss'
-        'patterns': ['include': 'source.css.scss']
+        begin: '^\\s*(`{3,})\\s*(?i:(scss))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.css.scss.asciidoc'
+        contentName: 'source.embedded.css.scss'
+        patterns: [include: 'source.css.scss']
       }
 
       # Matches SASS Markdown-style code blocks
@@ -1829,15 +1829,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(sass))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.sass.asciidoc'
-        'contentName': 'source.embedded.sass'
-        'patterns': ['include': 'source.sass']
+        begin: '^\\s*(`{3,})\\s*(?i:(sass))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.sass.asciidoc'
+        contentName: 'source.embedded.sass'
+        patterns: [include: 'source.sass']
       }
 
       # Matches XML Markdown-style code blocks
@@ -1848,15 +1848,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(xml))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.xml.asciidoc'
-        'contentName': 'text.embedded.xml'
-        'patterns': ['include': 'text.xml']
+        begin: '^\\s*(`{3,})\\s*(?i:(xml))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.xml.asciidoc'
+        contentName: 'text.embedded.xml'
+        patterns: [include: 'text.xml']
       }
 
       # Matches Rust Markdown-style code blocks
@@ -1867,15 +1867,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(rust|rs))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.rust.asciidoc'
-        'contentName': 'source.embedded.rust'
-        'patterns': ['include': 'source.rust']
+        begin: '^\\s*(`{3,})\\s*(?i:(rust|rs))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.rust.asciidoc'
+        contentName: 'source.embedded.rust'
+        patterns: [include: 'source.rust']
       }
 
       # Matches Dockerfile Markdown-style code blocks
@@ -1886,15 +1886,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(docker(file)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.dockerfile.asciidoc'
-        'contentName': 'source.embedded.dockerfile'
-        'patterns': ['include': 'source.dockerfile']
+        begin: '^\\s*(`{3,})\\s*(?i:(docker(file)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.dockerfile.asciidoc'
+        contentName: 'source.embedded.dockerfile'
+        patterns: [include: 'source.dockerfile']
       }
 
       # Matches properties Markdown-style code blocks
@@ -1905,15 +1905,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(properties))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.properties.asciidoc'
-        'contentName': 'source.embedded.asciidoc.properties'
-        'patterns': ['include': 'source.asciidoc.properties']
+        begin: '^\\s*(`{3,})\\s*(?i:(properties))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.properties.asciidoc'
+        contentName: 'source.embedded.asciidoc.properties'
+        patterns: [include: 'source.asciidoc.properties']
       }
 
       # Matches Makefile Markdown-style code blocks
@@ -1924,15 +1924,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(make(file)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.makefile.asciidoc'
-        'contentName': 'source.embedded.makefile'
-        'patterns': ['include': 'source.makefile']
+        begin: '^\\s*(`{3,})\\s*(?i:(make(file)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.makefile.asciidoc'
+        contentName: 'source.embedded.makefile'
+        patterns: [include: 'source.makefile']
       }
 
       # Matches Perl Markdown-style code blocks
@@ -1943,15 +1943,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(perl))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.perl.asciidoc'
-        'contentName': 'source.embedded.perl'
-        'patterns': ['include': 'source.perl']
+        begin: '^\\s*(`{3,})\\s*(?i:(perl))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.perl.asciidoc'
+        contentName: 'source.embedded.perl'
+        patterns: [include: 'source.perl']
       }
 
       # Matches Perl6 Markdown-style code blocks
@@ -1962,15 +1962,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(perl6))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.perl6.asciidoc'
-        'contentName': 'source.embedded.perl6'
-        'patterns': ['include': 'source.perl6']
+        begin: '^\\s*(`{3,})\\s*(?i:(perl6))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.perl6.asciidoc'
+        contentName: 'source.embedded.perl6'
+        patterns: [include: 'source.perl6']
       }
 
       # Matches Toml Markdown-style code blocks
@@ -1981,15 +1981,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(toml))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.toml.asciidoc'
-        'contentName': 'source.embedded.toml'
-        'patterns': ['include': 'source.toml']
+        begin: '^\\s*(`{3,})\\s*(?i:(toml))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.toml.asciidoc'
+        contentName: 'source.embedded.toml'
+        patterns: [include: 'source.toml']
       }
 
       # Matches Erlang Markdown-style code blocks
@@ -2000,15 +2000,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(erlang))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.erlang.asciidoc'
-        'contentName': 'source.embedded.erlang'
-        'patterns': ['include': 'source.erlang']
+        begin: '^\\s*(`{3,})\\s*(?i:(erlang))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.erlang.asciidoc'
+        contentName: 'source.embedded.erlang'
+        patterns: [include: 'source.erlang']
       }
 
       # Matches CSharp Markdown-style code blocks
@@ -2019,15 +2019,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(cs(harp)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.cs.asciidoc'
-        'contentName': 'source.embedded.cs'
-        'patterns': ['include': 'source.cs']
+        begin: '^\\s*(`{3,})\\s*(?i:(cs(harp)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.cs.asciidoc'
+        contentName: 'source.embedded.cs'
+        patterns: [include: 'source.cs']
       }
 
       # Matches PHP Markdown-style code blocks
@@ -2038,15 +2038,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(php))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.php.asciidoc'
-        'contentName': 'text.embedded.html.php'
-        'patterns': ['include': 'text.html.php']
+        begin: '^\\s*(`{3,})\\s*(?i:(php))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.php.asciidoc'
+        contentName: 'text.embedded.html.php'
+        patterns: [include: 'text.html.php']
       }
 
       # Matches Shell Markdown-style code blocks
@@ -2057,15 +2057,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(sh|bash|shell))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.shell.asciidoc'
-        'contentName': 'source.embedded.shell'
-        'patterns': ['include': 'source.shell']
+        begin: '^\\s*(`{3,})\\s*(?i:(sh|bash|shell))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.shell.asciidoc'
+        contentName: 'source.embedded.shell'
+        patterns: [include: 'source.shell']
       }
 
       # Matches Python Markdown-style code blocks
@@ -2076,15 +2076,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(py(thon)?))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.python.asciidoc'
-        'contentName': 'source.embedded.python'
-        'patterns': ['include': 'source.python']
+        begin: '^\\s*(`{3,})\\s*(?i:(py(thon)?))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.python.asciidoc'
+        contentName: 'source.embedded.python'
+        patterns: [include: 'source.python']
       }
 
       # Matches C Markdown-style code blocks
@@ -2095,15 +2095,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(c))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.c.asciidoc'
-        'contentName': 'source.embedded.c'
-        'patterns': ['include': 'source.c']
+        begin: '^\\s*(`{3,})\\s*(?i:(c))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.c.asciidoc'
+        contentName: 'source.embedded.c'
+        patterns: [include: 'source.c']
       }
 
       # Matches C++ Markdown-style code blocks
@@ -2119,15 +2119,15 @@
       #   }
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.cpp.asciidoc'
-        'contentName': 'source.embedded.cpp'
-        'patterns': ['include': 'source.cpp']
+        begin: '^\\s*(`{3,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.cpp.asciidoc'
+        contentName: 'source.embedded.cpp'
+        patterns: [include: 'source.cpp']
       }
 
       # Matches Objective C Markdown-style code blocks
@@ -2138,15 +2138,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(objc|objective-c))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.objc.asciidoc'
-        'contentName': 'source.embedded.objc'
-        'patterns': ['include': 'source.objc']
+        begin: '^\\s*(`{3,})\\s*(?i:(objc|objective-c))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.objc.asciidoc'
+        contentName: 'source.embedded.objc'
+        patterns: [include: 'source.objc']
       }
 
       # Matches Swift Markdown-style code blocks
@@ -2157,15 +2157,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(swift))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.swift.asciidoc'
-        'contentName': 'source.embedded.swift'
-        'patterns': ['include': 'source.swift']
+        begin: '^\\s*(`{3,})\\s*(?i:(swift))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.swift.asciidoc'
+        contentName: 'source.embedded.swift'
+        patterns: [include: 'source.swift']
       }
 
       # Matches HTML Markdown-style code blocks
@@ -2176,15 +2176,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(html))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.html.basic.asciidoc'
-        'contentName': 'text.embedded.html.basic'
-        'patterns': ['include': 'text.html.basic']
+        begin: '^\\s*(`{3,})\\s*(?i:(html))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.html.basic.asciidoc'
+        contentName: 'text.embedded.html.basic'
+        patterns: [include: 'text.html.basic']
       }
 
       # Matches Elixir Markdown-style code blocks
@@ -2195,15 +2195,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(elixir))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.elixir.asciidoc'
-        'contentName': 'source.embedded.elixir'
-        'patterns': ['include': 'source.elixir']
+        begin: '^\\s*(`{3,})\\s*(?i:(elixir))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.elixir.asciidoc'
+        contentName: 'source.embedded.elixir'
+        patterns: [include: 'source.elixir']
       }
 
       # Matches Diff Markdown-style code blocks
@@ -2214,15 +2214,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(diff|patch|rej))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.diff.asciidoc'
-        'contentName': 'source.embedded.diff'
-        'patterns': ['include': 'source.diff']
+        begin: '^\\s*(`{3,})\\s*(?i:(diff|patch|rej))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.diff.asciidoc'
+        contentName: 'source.embedded.diff'
+        patterns: [include: 'source.diff']
       }
 
       # Matches Julia Markdown-style code blocks
@@ -2233,15 +2233,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(julia))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.julia.asciidoc'
-        'contentName': 'source.embedded.julia'
-        'patterns': ['include': 'source.julia']
+        begin: '^\\s*(`{3,})\\s*(?i:(julia))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.julia.asciidoc'
+        contentName: 'source.embedded.julia'
+        patterns: [include: 'source.julia']
       }
 
       # Matches R Markdown-style code blocks
@@ -2252,15 +2252,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(r))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.r.asciidoc'
-        'contentName': 'source.embedded.r'
-        'patterns': ['include': 'source.r']
+        begin: '^\\s*(`{3,})\\s*(?i:(r))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.r.asciidoc'
+        contentName: 'source.embedded.r'
+        patterns: [include: 'source.r']
       }
 
       # Matches Haskell Markdown-style code blocks
@@ -2271,15 +2271,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(haskell))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.haskell.asciidoc'
-        'contentName': 'source.embedded.haskell'
-        'patterns': ['include': 'source.haskell']
+        begin: '^\\s*(`{3,})\\s*(?i:(haskell))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.haskell.asciidoc'
+        contentName: 'source.embedded.haskell'
+        patterns: [include: 'source.haskell']
       }
 
       # Matches ELM Markdown-style code blocks
@@ -2290,15 +2290,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(elm))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.elm.asciidoc'
-        'contentName': 'source.embedded.elm'
-        'patterns': ['include': 'source.elm']
+        begin: '^\\s*(`{3,})\\s*(?i:(elm))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.elm.asciidoc'
+        contentName: 'source.embedded.elm'
+        patterns: [include: 'source.elm']
       }
 
       # Matches SQL Markdown-style code blocks
@@ -2309,15 +2309,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(sql))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.sql.asciidoc'
-        'contentName': 'source.embedded.sql'
-        'patterns': ['include': 'source.sql']
+        begin: '^\\s*(`{3,})\\s*(?i:(sql))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.sql.asciidoc'
+        contentName: 'source.embedded.sql'
+        patterns: [include: 'source.sql']
       }
 
       # Matches Clojure Markdown-style code blocks
@@ -2328,15 +2328,15 @@
       #   ...
       #   ```
       {
-        'begin': '^\\s*(`{3,})\\s*(?i:(clojure))\\s*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.code.clojure.asciidoc'
-        'contentName': 'source.embedded.clojure'
-        'patterns': ['include': 'source.clojure']
+        begin: '^\\s*(`{3,})\\s*(?i:(clojure))\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.code.clojure.asciidoc'
+        contentName: 'source.embedded.clojure'
+        patterns: [include: 'source.clojure']
       }
 
       # Matches language-agnostic Markdown code blocks
@@ -2351,13 +2351,13 @@
       #   end
       #   ```
       {
-        'begin': '^\\s*(`{3,}).*$'
-        'beginCaptures':
-          '0': 'name': 'support.asciidoc'
-        'end': '^\\s*\\1\\s*$'
-        'endCaptures':
-          '0': 'name': 'support.asciidoc'
-        'name': 'markup.raw.asciidoc'
+        begin: '^\\s*(`{3,}).*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        end: '^\\s*\\1\\s*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+        name: 'markup.raw.asciidoc'
       }
 
     ]

--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -462,16 +462,16 @@
       #   }).listen(1337, '127.0.0.1');
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(javascript|js))\\]$'
+        'begin': '^\\[source,\\s*(?i:(javascript|js))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.js.asciidoc'
@@ -494,16 +494,16 @@
       #   end
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(ruby|rb))\\]$'
+        'begin': '^\\[source,\\s*(?i:(ruby|rb))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.ruby.asciidoc'
@@ -522,16 +522,16 @@
       #   ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(go(lang)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(go(lang)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.go.asciidoc'
@@ -550,16 +550,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(java))\\]$'
+        'begin': '^\\[source,\\s*(?i:(java))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.java.asciidoc'
@@ -578,16 +578,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(markdown|mdown|md))\\]$'
+        'begin': '^\\[source,\\s*(?i:(markdown|mdown|md))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.gfm.asciidoc'
@@ -606,16 +606,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(ya?ml))\\]$'
+        'begin': '^\\[source,\\s*(?i:(ya?ml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.yaml.asciidoc'
@@ -634,16 +634,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(coffee-?(script)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(coffee-?(script)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.coffee.asciidoc'
@@ -662,16 +662,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(json))\\]$'
+        'begin': '^\\[source,\\s*(?i:(json))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.json.asciidoc'
@@ -690,16 +690,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(css))\\]$'
+        'begin': '^\\[source,\\s*(?i:(css))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.css.asciidoc'
@@ -718,16 +718,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(less))\\]$'
+        'begin': '^\\[source,\\s*(?i:(less))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.css.less.asciidoc'
@@ -746,16 +746,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(scss|sass))\\]$'
+        'begin': '^\\[source,\\s*(?i:(scss|sass))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.css.scss.asciidoc'
@@ -774,16 +774,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(xml))\\]$'
+        'begin': '^\\[source,\\s*(?i:(xml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.xml.asciidoc'
@@ -802,16 +802,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(rust|rs))\\]$'
+        'begin': '^\\[source,\\s*(?i:(rust|rs))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.rust.asciidoc'
@@ -830,16 +830,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(docker(file)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(docker(file)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.dockerfile.asciidoc'
@@ -858,16 +858,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(properties))\\]$'
+        'begin': '^\\[source,\\s*(?i:(properties))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.git-config.asciidoc'
@@ -886,16 +886,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(make(file)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(make(file)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.makefile.asciidoc'
@@ -914,16 +914,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(perl))\\]$'
+        'begin': '^\\[source,\\s*(?i:(perl))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.perl.asciidoc'
@@ -942,16 +942,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(perl6))\\]$'
+        'begin': '^\\[source,\\s*(?i:(perl6))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.perl6.asciidoc'
@@ -970,16 +970,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(toml))\\]$'
+        'begin': '^\\[source,\\s*(?i:(toml))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.toml.asciidoc'
@@ -998,16 +998,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(erlang))\\]$'
+        'begin': '^\\[source,\\s*(?i:(erlang))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.erlang.asciidoc'
@@ -1026,16 +1026,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(cs(harp)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(cs(harp)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.cs.asciidoc'
@@ -1054,16 +1054,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(php))\\]$'
+        'begin': '^\\[source,\\s*(?i:(php))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.php.asciidoc'
@@ -1082,16 +1082,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(sh|bash|shell))\\]$'
+        'begin': '^\\[source,\\s*(?i:(sh|bash|shell))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.shell.asciidoc'
@@ -1110,16 +1110,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(py(thon)?))\\]$'
+        'begin': '^\\[source,\\s*(?i:(py(thon)?))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.python.asciidoc'
@@ -1138,16 +1138,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(c))\\]$'
+        'begin': '^\\[source,\\s*(?i:(c))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.c.asciidoc'
@@ -1166,16 +1166,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
+        'begin': '^\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.cpp.asciidoc'
@@ -1194,16 +1194,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(objc|objective-c))\\]$'
+        'begin': '^\\[source,\\s*(?i:(objc|objective-c))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.objc.asciidoc'
@@ -1222,16 +1222,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(swift))\\]$'
+        'begin': '^\\[source,\\s*(?i:(swift))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.swift.asciidoc'
@@ -1250,16 +1250,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(html))\\]$'
+        'begin': '^\\[source,\\s*(?i:(html))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.html.asciidoc'
@@ -1278,16 +1278,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(elixir))\\]$'
+        'begin': '^\\[source,\\s*(?i:(elixir))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.elixir.asciidoc'
@@ -1306,16 +1306,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(diff|patch|rej))\\]$'
+        'begin': '^\\[source,\\s*(?i:(diff|patch|rej))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.diff.asciidoc'
@@ -1334,16 +1334,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(julia))\\]$'
+        'begin': '^\\[source,\\s*(?i:(julia))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.julia.asciidoc'
@@ -1362,16 +1362,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(r))\\]$'
+        'begin': '^\\[source,\\s*(?i:(r))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.r.asciidoc'
@@ -1390,16 +1390,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(haskell))\\]$'
+        'begin': '^\\[source,\\s*(?i:(haskell))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.haskell.asciidoc'
@@ -1418,16 +1418,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(elm))\\]$'
+        'begin': '^\\[source,\\s*(?i:(elm))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.elm.asciidoc'
@@ -1446,16 +1446,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(sql))\\]$'
+        'begin': '^\\[source,\\s*(?i:(sql))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.sql.asciidoc'
@@ -1474,16 +1474,16 @@
       #  ...
       #   ----
       {
-        'begin': '^\\s*\\[source,\\s*(?i:(clojure))\\]$'
+        'begin': '^\\[source,\\s*(?i:(clojure))\\]$'
         'beginCaptures':
           '0': 'name': 'support.asciidoc'
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.code.clojure.asciidoc'
@@ -1512,10 +1512,10 @@
         'end': '(?<=----)[\\r\\n]+$'
         'patterns': [
           {
-            'begin': '^\\s*(-{4,})\\s*$'
+            'begin': '^(-{4,})\\s*$'
             'beginCaptures':
               '0': 'name': 'support.asciidoc'
-            'end': '^\\s*\\1*$'
+            'end': '^\\1*$'
             'endCaptures':
               '0': 'name': 'support.asciidoc'
             'name': 'markup.raw.asciidoc'

--- a/grammars/properties-lang.cson
+++ b/grammars/properties-lang.cson
@@ -1,0 +1,97 @@
+# Hack for fix grammar parsing bug (`java-properties`, `git-config`)
+name: 'Hack for properties'
+scopeName: 'source.asciidoc.properties'
+fileTypes: [
+  'ASCIIDOC_PROPERTIES'
+]
+patterns: [
+  {
+    include: '#section'
+  }
+  {
+    include: '#value_pair'
+  }
+  {
+    include: '#comment'
+  }
+]
+repository:
+  # Comment grammar
+  comment:
+    match: '((#|;).*$\\n?)'
+    captures:
+      1:
+        name: 'comment.line.number-sign.asciidoc.properties'
+      2:
+        name: 'punctuation.definition.comment.asciidoc.properties'
+      3:
+        name: 'comment.line.semi-colon.asciidoc.properties'
+      4:
+        name: 'punctuation.definition.comment.asciidoc.properties'
+  # Section header grammar
+  section:
+    match: '^\\[\\s*([\\w_-]+)(?:\\s+((")(?:[^"\\\\]|^\\\\["\\\\])*("))|\\.([\\w_-]+))?\\s*\\]'
+    name: 'meta.section.asciidoc.properties'
+    captures:
+      1:
+        name: 'entity.name.section.asciidoc.properties'
+      2:
+        name: 'entity.name.section.subsection.asciidoc.properties'
+      3:
+        name: 'punctuation.definition.section.subsection.begin.asciidoc.properties'
+      4:
+        name: 'punctuation.definition.section.subsection.end.asciidoc.properties'
+      5:
+        name: 'entity.name.section.subsection.asciidoc.properties'
+  # Value pair
+  'value_pair':
+    name: 'meta.value-pair.section-item.asciidoc.properties'
+    begin: '([-\\w]+)\\s*(=)\\s*(?!$)'
+    captures:
+      1:
+        name: 'support.constant.asciidoc.properties'
+      2:
+        name: 'punctuation.separator.key-value.asciidoc.properties'
+    end: '$|(?=[#;])'
+    patterns: [
+      {
+        include: '#boolean'
+      }
+      {
+        include: '#escaped-string'
+      }
+      {
+        include: '#string'
+      }
+      {
+        include: '#comment'
+      }
+    ]
+  # Boolean value
+  boolean:
+    match: '\\b(?i:yes|no|0|1|true|false)\\b'
+    name: 'constant.language.boolean.asciidoc.properties'
+  # String value
+  string:
+    name: 'string.quoted.double.asciidoc.properties'
+    begin: '"'
+    beginCaptures:
+      0:
+        name: 'punctuation.definition.string.begin.asciidoc.properties'
+    end: '"'
+    endCaptures:
+      0:
+        name: 'punctuation.definition.string.end.asciidoc.properties'
+    patterns: [
+      {
+        match: '\\\\[ntb"\\\\]'
+        name: 'constant.character.escape.asciidoc.properties'
+      }
+      {
+        match: '\\\\.'
+        name: 'invalid.illegal.unknown-escape.asciidoc.properties'
+      }
+    ]
+  'escaped-string':
+    match: '\\\\"'
+    name: 'constant.character.escape.asciidoc.properties'

--- a/spec/asciidoc-spec.coffee
+++ b/spec/asciidoc-spec.coffee
@@ -297,3 +297,36 @@ describe "AsciiDoc grammar", ->
 
   it "tokenizes passthrough block", ->
     testBlock "+", "markup.block.passthrough.asciidoc"
+
+  it "tokenizes code block followed by others grammar parts", ->
+    tokens = grammar.tokenizeLines("""
+                                    [source,shell]
+                                    ----
+                                    ls -l <1>
+                                    cd .. <2>
+                                    ----
+                                    <1> *Grammars* _definition_
+                                    <2> *CoffeeLint* _rules_
+                                    """)
+    expect(tokens).toHaveLength(7) # Number of lines
+    expect(tokens[0]).toHaveLength(1)
+    expect(tokens[0][0]).toEqual value: '[source,shell]', scopes: ["source.asciidoc", "support.asciidoc"]
+    expect(tokens[1]).toHaveLength(1)
+    expect(tokens[1][0]).toEqual value: "----", scopes: ["source.asciidoc", "markup.code.shell.asciidoc", "support.asciidoc"]
+    expect(tokens[2]).toHaveLength(1)
+    expect(tokens[2][0]).toEqual value: "ls -l <1>", scopes: ["source.asciidoc", "markup.code.shell.asciidoc", "source.embedded.shell"]
+    expect(tokens[3]).toHaveLength(1)
+    expect(tokens[3][0]).toEqual value: "cd .. <2>", scopes: ["source.asciidoc", "markup.code.shell.asciidoc", "source.embedded.shell"]
+    expect(tokens[4]).toHaveLength(2)
+    expect(tokens[4][0]).toEqual value: "----", scopes: ["source.asciidoc", "markup.code.shell.asciidoc", "support.asciidoc"]
+    expect(tokens[4][1]).toEqual value: "", scopes: ["source.asciidoc"]
+    expect(tokens[5]).toHaveLength(4)
+    expect(tokens[5][0]).toEqual value: "<1> ", scopes: ["source.asciidoc"]
+    expect(tokens[5][1]).toEqual value: "*Grammars*", scopes: ["source.asciidoc", "markup.bold.asciidoc"]
+    expect(tokens[5][2]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[5][3]).toEqual value: "_definition_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]
+    expect(tokens[5]).toHaveLength(4)
+    expect(tokens[6][0]).toEqual value: "<2> ", scopes: ["source.asciidoc"]
+    expect(tokens[6][1]).toEqual value: "*CoffeeLint*", scopes: ["source.asciidoc", "markup.bold.asciidoc"]
+    expect(tokens[6][2]).toEqual value: " ", scopes: ["source.asciidoc"]
+    expect(tokens[6][3]).toEqual value: "_rules_", scopes: ["source.asciidoc", "markup.italic.asciidoc"]

--- a/spec/fixtures/asciidoctor-lang.adoc
+++ b/spec/fixtures/asciidoctor-lang.adoc
@@ -180,6 +180,35 @@ cubes = (math.cube num for num in list)
 ----
 
 
+== TypeScript (with Plugin)
+
+[source,typescript]
+----
+class Greeter {
+    constructor(public greeting: string) { }
+    greet() {
+        return "<h1>" + this.greeting + "</h1>";
+    }
+};
+
+var greeter = new Greeter("Hello, world!");
+
+document.body.innerHTML = greeter.greet();
+----
+
+```typescript
+class Greeter {
+    constructor(public greeting: string) { }
+    greet() {
+        return "<h1>" + this.greeting + "</h1>";
+    }
+};
+
+var greeter = new Greeter("Hello, world!");
+
+document.body.innerHTML = greeter.greet();
+```
+
 == JSON
 
 ```json
@@ -269,7 +298,7 @@ p {
 ----
 
 
-== SASS (new)
+== SASS
 
 ```scss
 $font-stack:    Helvetica, sans-serif;
@@ -750,6 +779,7 @@ int main()
 @end
 ----
 
+
 == Swift (with plugin)
 
 ```swift
@@ -819,6 +849,7 @@ receive do
   {:msg, contents} -> IO.puts contents
 end
 ```
+
 
 [source,elixir]
 ----

--- a/spec/fixtures/asciidoctor-lang.adoc
+++ b/spec/fixtures/asciidoctor-lang.adoc
@@ -445,22 +445,42 @@ COPY /tmp /tmp
 ----
 
 
-== Properties *BUG !*
+== Properties
 
-// ```properties
-// # comment
-// [user]
-//    name = John Doe
-//    email = example@examplecom
-// ```
+```properties
+# comment
+foo = foo-{0}-bar\"foo\"
+; comment
+[user]
+    name = John Doe ; comment
+    email = example@examplecom # comment
+[section-foo "riooeri"]
+    key = \"foobar\" ; comment
+    key = "foobar" # comment
+[section.foo]
+    key = \"foobar\" ; comment
+    key = "foobar" # comment
+[alias]
+    lg = log --graph --pretty=tformat:'%Cred%h%Creset %Cblue%G?%Creset -%C(auto)%d%Creset %s %Cgreen(%an %ar)%Creset'
+```
 
-// [source,properties]
-// ----
-// # comment
-// [user]
-//    name = John Doe
-//    email = example@examplecom
-// ----
+[source,properties]
+----
+# comment
+foo = foo-{0}-bar\"foo\"
+; comment
+[user]
+    name = John Doe ; comment
+    email = example@examplecom # comment
+[section-foo "riooeri"]
+    key = \"foobar\" ; comment
+    key = "foobar" # comment
+[section.foo]
+    key = \"foobar\" ; comment
+    key = "foobar" # comment
+[alias]
+    lg = log --graph --pretty=tformat:'%Cred%h%Creset %Cblue%G?%Creset -%C(auto)%d%Creset %s %Cgreen(%an %ar)%Creset'
+----
 
 
 == Makefile

--- a/spec/fixtures/asciidoctor-lang.adoc
+++ b/spec/fixtures/asciidoctor-lang.adoc
@@ -298,7 +298,7 @@ p {
 ----
 
 
-== SASS
+== SASS / SCSS
 
 ```scss
 $font-stack:    Helvetica, sans-serif;
@@ -319,6 +319,25 @@ body {
   font: 100% $font-stack;
   color: $primary-color;
 }
+----
+
+```sass
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+
+body
+  font: 100% $font-stack
+  color: $primary-color
+```
+
+[source,sass]
+----
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+
+body
+  font: 100% $font-stack
+  color: $primary-color
 ----
 
 

--- a/spec/fixtures/asciidoctor-lang.adoc
+++ b/spec/fixtures/asciidoctor-lang.adoc
@@ -216,21 +216,20 @@ p {
 }
 ```
 
-*BUG !*
-// [source,css]
-// ----
-// body {
-//   background-color: #d0e4fe;
-// }
-// h1 {
-//   color: orange;
-//   text-align: center;
-// }
-// p {
-//   font-family: "Times New Roman";
-//   font-size: 20px;
-// }
-// ----
+[source,css]
+----
+body {
+  background-color: #d0e4fe;
+}
+h1 {
+  color: orange;
+  text-align: center;
+}
+p {
+  font-family: "Times New Roman";
+  font-size: 20px;
+}
+----
 
 == Less
 
@@ -1000,4 +999,20 @@ import "net/http"
 func main() {
         panic(http.ListenAndServe(":8080", http.FileServer(http.Dir("."))))
 }
+----
+
+
+== No language
+
+```
+foobar
+foobar
+foobar
+```
+
+[source]
+----
+foobar
+foobar
+foobar
 ----

--- a/spec/properties-lang-spec.coffee
+++ b/spec/properties-lang-spec.coffee
@@ -1,0 +1,99 @@
+describe 'Properties grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc.properties'
+
+  # convenience function during development
+  debug = (tokens) ->
+    console.log(JSON.stringify(tokens, null, ' '))
+
+  it 'load the "properties" config grammar', ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe 'source.asciidoc.properties'
+
+  describe 'Should parse "section" when', ->
+    it 'was a simple word', ->
+      {tokens} = grammar.tokenizeLine '[foobar]'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+      expect(tokens[1]).toEqual value: 'foobar', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.asciidoc.properties']
+      expect(tokens[2]).toEqual value: ']', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+
+    it 'have a subsection separate by a dot', ->
+      {tokens} = grammar.tokenizeLine '[foo.bar]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.asciidoc.properties']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+      expect(tokens[3]).toEqual value: 'bar', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.subsection.asciidoc.properties']
+      expect(tokens[4]).toEqual value: ']', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+
+    it 'have a subsection with double-quote', ->
+      {tokens} = grammar.tokenizeLine '[foo "bar"]'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.asciidoc.properties']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+      expect(tokens[3]).toEqual value: '"', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.subsection.asciidoc.properties', 'punctuation.definition.section.subsection.begin.asciidoc.properties']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.subsection.asciidoc.properties']
+      expect(tokens[5]).toEqual value: '"', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties', 'entity.name.section.subsection.asciidoc.properties', 'punctuation.definition.section.subsection.end.asciidoc.properties']
+      expect(tokens[6]).toEqual value: ']', scopes: ['source.asciidoc.properties', 'meta.section.asciidoc.properties']
+
+  describe 'Should parse "comment" when', ->
+    it 'start by a hash', ->
+      {tokens} = grammar.tokenizeLine '# comment'
+      expect(tokens).toHaveLength 2
+      expect(tokens[0]).toEqual value: '#', scopes: ['source.asciidoc.properties', 'comment.line.number-sign.asciidoc.properties', 'punctuation.definition.comment.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' comment', scopes: ['source.asciidoc.properties', 'comment.line.number-sign.asciidoc.properties']
+
+    it 'start by a ;', ->
+      {tokens} = grammar.tokenizeLine '; comment'
+      expect(tokens).toHaveLength 2
+      expect(tokens[0]).toEqual value: ';', scopes: ['source.asciidoc.properties', 'comment.line.number-sign.asciidoc.properties', 'punctuation.definition.comment.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' comment', scopes: ['source.asciidoc.properties', 'comment.line.number-sign.asciidoc.properties']
+
+  describe 'Should parse "value pair" when', ->
+    it 'have a simple value', ->
+      {tokens} = grammar.tokenizeLine 'name = foobar'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqual value: 'name', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'support.constant.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'punctuation.separator.key-value.asciidoc.properties']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[4]).toEqual value: 'foobar', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+
+    it 'have a value embedded in double quote', ->
+      {tokens} = grammar.tokenizeLine 'name = "foobar"'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqual value: 'name', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'support.constant.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'punctuation.separator.key-value.asciidoc.properties']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[4]).toEqual value: '"', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'string.quoted.double.asciidoc.properties', 'punctuation.definition.string.begin.asciidoc.properties']
+      expect(tokens[5]).toEqual value: 'foobar', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'string.quoted.double.asciidoc.properties']
+      expect(tokens[6]).toEqual value: '"', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'string.quoted.double.asciidoc.properties', 'punctuation.definition.string.end.asciidoc.properties']
+
+    it 'have a boolean value', ->
+      {tokens} = grammar.tokenizeLine 'name = true'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqual value: 'name', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'support.constant.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'punctuation.separator.key-value.asciidoc.properties']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[4]).toEqual value: 'true', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'constant.language.boolean.asciidoc.properties']
+
+    it 'have a value contains escaped double quote', ->
+      {tokens} = grammar.tokenizeLine 'name = \\"foobar\\"'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqual value: 'name', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'support.constant.asciidoc.properties']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'punctuation.separator.key-value.asciidoc.properties']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[4]).toEqual value: '\\"', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'constant.character.escape.asciidoc.properties']
+      expect(tokens[5]).toEqual value: 'foobar', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties']
+      expect(tokens[6]).toEqual value: '\\"', scopes: ['source.asciidoc.properties', 'meta.value-pair.section-item.asciidoc.properties', 'constant.character.escape.asciidoc.properties']


### PR DESCRIPTION
- [x] all the code blocks can be immediately followed by other grammar.
- [x] fix bug with CSS  code block
- [x] add TypeScript language support
- [x] split SCSS to SASS and SCSS
- [x] add custom 'properties' grammar

**Note:**
I use `grammar.tokenizeLines` in the tests because `grammar.tokenizeLine` doesn't work properly with multi-lines content.
- `grammar.tokenizeLine` give false positive with multi-lines because it parse multi-lines as a single line.

Fix #20, #39,  #59 
