### PR TITLE
Porting AsciiDoctor regex for monospace

### DIFF
--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -381,8 +381,9 @@
       #
       #   `Text in {backticks}` renders exactly as entered, in `monospace`.
       {
-        'match': '(?<=^|\\s)`[^`]+`'
-        'name': 'markup.raw.inline.asciidoc'
+        'match': '(^|[^\\p{Word};:"\'`\\}])((?:\\[([^\\\\]]+?)\\])?`(\\S|\\S.*?\\S)`(?![\\p{Word}"\'`]))'
+        'captures':
+          '2': 'name': 'markup.raw.inline.asciidoc'
       }
 
       # Matches HTML entities


### PR DESCRIPTION
Porting the https://github.com/asciidoctor/asciidoctor/blob/v1.5.4/lib/asciidoctor.rb#L1177-L1178 to the grammar.

fix #38 
