### PR TITLE
resolves #65 properly match and label attribute entries

### DIFF
--- a/grammars/asciidoc.cson
+++ b/grammars/asciidoc.cson
@@ -60,11 +60,15 @@ patterns: [
   #
   #   :icons: font
   #   :sectanchors:
+  #   :!compat-mode:
   {
-    'match': '(\\:)([^\/\\:\\s]+)(\\:)(\\s+\\S+)?$'
-    'name': 'support.constant.asciidoc'
+    'match': '^(:)(!?\\w[\\p{Blank}\\w-]*?|\\w[\\p{Blank}\\w-]*?!?)(:)(\\p{Blank}+.*)?$'
+    'name': 'meta.definition.attribute-entry.asciidoc'
     'captures':
-      '4': 'name': 'variable.asciidoc'
+      '1': 'name': 'punctuation.separator.attribute-entry.asciidoc'
+      '2': 'name': 'support.constant.attribute-name.asciidoc'
+      '3': 'name': 'punctuation.separator.attribute-entry.asciidoc'
+      '4': 'name': 'string.unquoted.attribute-value.asciidoc'
   }
 
   # Matches block comments


### PR DESCRIPTION
- permit any characters in value
- permit name to begin or end with !, but not both
- use more semantic labels
- label punctuation surrounding attribute entry