### PR TITLE
Adding in *.adoc.txt extension option.

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -5,6 +5,7 @@ fileTypes: [
   "asc"
   "adoc"
   "asciidoc"
+  "adoc.txt"
 ]
 maxTokensPerLine: 100
 patterns: [


### PR DESCRIPTION
Allow for filename.adoc.txt to be recognized.