### PR TITLE
Markdown-style block quotes support

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -614,6 +614,16 @@ repository:
         ]
         end: "\\1"
       }
+      {
+        name: "markup.italic.quotes.asciidoc"
+        begin: "^\\p{Blank}*(>) "
+        patterns: [
+          {
+            include: "#inlines"
+          }
+        ]
+        end: "^\\p{Blank}*?$"
+      }
     ]
   "sidebar-block":
     patterns: [

--- a/grammars/repositories/blocks/quote-grammar.cson
+++ b/grammars/repositories/blocks/quote-grammar.cson
@@ -28,13 +28,6 @@ patterns: [
     3: name: 'none.quotes.attribution.asciidoc'
     5: name: 'none.quotes.citetitle.asciidoc'
   end: '\\]$'
-  # name: 'markup.block.quotes.attributes.asciidoc'
-  # begin: '^\\[(quote|verse)(, ([\\w ]+))?(, ([\\w ]+))?'
-  # beginCaptures:
-  #   1: name: 'markup.quotes.label.asciidoc'
-  #   3: name: 'markup.quotes.attribution.asciidoc'
-  #   5: name: 'markup.quotes.citetitle.asciidoc'
-  # end: '\\]$'
 ,
   # Matches quote block
   name: 'markup.italic.quotes.asciidoc'
@@ -43,10 +36,17 @@ patterns: [
     include: '#inlines'
   ]
   end: '\\1'
-  # name: 'markup.block.quotes.asciidoc'
-  # begin: '(^_{4,}$)'
-  # patterns: [
-  #   include: '#inlines'
-  # ]
-  # end: '\\1'
+,
+  # Matches Markdown style quote
+  #
+  # > I don't like it, and I'm sorry I ever had anything to do with it.
+  # Erwin Schrödinger, Sorry
+  #
+  name: 'markup.italic.quotes.asciidoc'
+  begin: '^\\p{Blank}*(>) '
+  patterns: [
+    include: '#inlines'
+  ]
+  end: '^\\p{Blank}*?$'
+
 ]

--- a/spec/blocks/quote-grammar-spec.coffee
+++ b/spec/blocks/quote-grammar-spec.coffee
@@ -39,7 +39,7 @@ describe 'Should tokenizes quote block when', ->
     expect(tokens[3]).toHaveLength 1
     expect(tokens[3][0]).toEqual value: '____', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
 
-  it 'tokenizes quote declarations with attribution', ->
+  it 'quote declarations with attribution', ->
     {tokens} = grammar.tokenizeLine '[verse, Homer Simpson]\n'
     expect(tokens).toHaveLength 6
     expect(tokens[0]).toEqual value: '[', scopes: ['source.asciidoc', 'markup.italic.quotes.attributes.asciidoc']
@@ -49,7 +49,7 @@ describe 'Should tokenizes quote block when', ->
     expect(tokens[4]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.italic.quotes.attributes.asciidoc']
     expect(tokens[5]).toEqual value: '\n', scopes: ['source.asciidoc']
 
-  it 'tokenizes quote declarations with attribution and citation', ->
+  it 'quote declarations with attribution and citation', ->
     {tokens} = grammar.tokenizeLine '[quote, Erwin Schrödinger, Sorry]\n'
     expect(tokens).toHaveLength 8
     expect(tokens[0]).toEqual value: '[', scopes: ['source.asciidoc', 'markup.italic.quotes.attributes.asciidoc']
@@ -60,3 +60,51 @@ describe 'Should tokenizes quote block when', ->
     expect(tokens[5]).toEqual value: 'Sorry', scopes: ['source.asciidoc', 'markup.italic.quotes.attributes.asciidoc', 'none.quotes.citetitle.asciidoc']
     expect(tokens[6]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.italic.quotes.attributes.asciidoc']
     expect(tokens[7]).toEqual value: '\n', scopes: ['source.asciidoc']
+
+  it 'with Markdown style and mix content', ->
+    tokens = grammar.tokenizeLines '''
+      > I've got Markdown in my AsciiDoc!
+      >
+      > *strong*
+      > Yep. AsciiDoc and Markdown share a lot of common syntax already.
+      '''
+    expect(tokens).toHaveLength 4
+    expect(tokens[0]).toHaveLength 2
+    expect(tokens[0][0]).toEqual value: '> ', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[0][1]).toEqual value: 'I\'ve got Markdown in my AsciiDoc!', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqual value: '>', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[2]).toHaveLength 4
+    expect(tokens[2][0]).toEqual value: '> ', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[2][1]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[2][2]).toEqual value: 'strong', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[2][3]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[3]).toHaveLength 1
+    expect(tokens[3][0]).toEqual value: '> Yep. AsciiDoc and Markdown share a lot of common syntax already.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+
+  it 'with Markdown style and multi-lines', ->
+    tokens = grammar.tokenizeLines '''
+      foobar
+      > I don't like it, and I'm sorry I ever had anything to do with it.
+      > Erwin Schrödinger, Sorry
+      foobar foobar
+      foobar
+
+      foobar
+      '''
+    expect(tokens).toHaveLength 7
+    expect(tokens[0]).toHaveLength 1
+    expect(tokens[0][0]).toEqual value: 'foobar', scopes: ['source.asciidoc']
+    expect(tokens[1]).toHaveLength 2
+    expect(tokens[1][0]).toEqual value: '> ', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[1][1]).toEqual value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[2]).toHaveLength 1
+    expect(tokens[2][0]).toEqual value: '> Erwin Schrödinger, Sorry', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[3]).toHaveLength 1
+    expect(tokens[3][0]).toEqual value: 'foobar foobar', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[4]).toHaveLength 1
+    expect(tokens[4][0]).toEqual value: 'foobar', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[5]).toHaveLength 1
+    expect(tokens[5][0]).toEqual value: '', scopes: ['source.asciidoc']
+    expect(tokens[6]).toHaveLength 1
+    expect(tokens[6][0]).toEqual value: 'foobar', scopes: ['source.asciidoc']


### PR DESCRIPTION
## Description

The last part's of the #27:

- [x] Markdown-style headings
- [x] Markdown-style fenced code blocks
- [x] Markdown-style block quotes
- [x] Markdown-style horizontal rules

http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#markdown-compatibility

## Syntax example


```asciidoc
foobar
foobar
> I don't like it, and I'm sorry I ever had anything to do with it.
> Erwin Schrödinger, Sorry
foobar foobar
foobar

foobar

> I've got Markdown in my AsciiDoc!
>
> *strong*
> Yep. AsciiDoc and Markdown share a lot of common syntax already.

foobar
```

## Screenshots

![capture du 2016-05-02 23-06-41](https://cloud.githubusercontent.com/assets/5674651/14967983/92badf8e-10ba-11e6-9f6c-9334d3282d6b.png)
