### PR TITLE
Admonition multi-lines support

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -547,13 +547,13 @@ repository:
         begin: "^((NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\:)\\p{Blank}+"
         captures:
           "1":
-            name: "support.constant.asciidoc"
+            name: "support.constant.label.asciidoc"
         patterns: [
           {
             include: "#inlines"
           }
         ]
-        end: "$"
+        end: "^\\p{Blank}*$"
       }
     ]
   "example-block":

--- a/grammars/repositories/blocks/admonition-grammar.cson
+++ b/grammars/repositories/blocks/admonition-grammar.cson
@@ -13,9 +13,9 @@ patterns: [
   name: 'markup.admonition.asciidoc'
   begin: '^((NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\:)\\p{Blank}+'
   captures:
-    1: name: 'support.constant.asciidoc'
+    1: name: 'support.constant.label.asciidoc'
   patterns: [
     include: '#inlines'
   ]
-  end: '$'
+  end: '^\\p{Blank}*$'
 ]

--- a/spec/blocks/admonition-grammar-spec.coffee
+++ b/spec/blocks/admonition-grammar-spec.coffee
@@ -18,5 +18,72 @@ describe 'Should tokenizes admonition when', ->
 
   it 'start with NOTE:', ->
     {tokens} = grammar.tokenizeLine 'NOTE: This is a note'
-    expect(tokens[0]).toEqual value: 'NOTE:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.asciidoc']
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toEqual value: 'NOTE:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
     expect(tokens[2]).toEqual value: 'This is a note', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+
+  it 'start with NOTE: and have several lines', ->
+    tokens = grammar.tokenizeLines '''
+      foobar
+
+      NOTE: An admonition paragraph draws the reader's attention to
+      auxiliary information.
+      Its purpose is *determined* by the label
+      at the _beginning_ of the paragraph.
+
+      foobar
+      '''
+    expect(tokens).toHaveLength 8 # Number of lines
+    expect(tokens[0]).toHaveLength 1
+    expect(tokens[0][0]).toEqual value: 'foobar', scopes: ['source.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqual value: '', scopes: ['source.asciidoc']
+    expect(tokens[2]).toHaveLength 3
+    expect(tokens[2][0]).toEqual value: 'NOTE:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[2][1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[2][2]).toEqual value: 'An admonition paragraph draws the reader\'s attention to', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[3]).toHaveLength 1
+    expect(tokens[3][0]).toEqual value: 'auxiliary information.', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[4]).toHaveLength 5
+    expect(tokens[4][0]).toEqual value: 'Its purpose is ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[4][1]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[4][2]).toEqual value: 'determined', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[4][3]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[4][4]).toEqual value: ' by the label', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[5]).toHaveLength 3
+    expect(tokens[5][0]).toEqual value: 'at the ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[5][1]).toEqual value: '_beginning_', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'markup.italic.asciidoc']
+    expect(tokens[5][2]).toEqual value: ' of the paragraph.', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[6]).toHaveLength 1
+    expect(tokens[6][0]).toEqual value: '', scopes: ['source.asciidoc']
+    expect(tokens[7]).toHaveLength 1
+    expect(tokens[7][0]).toEqual value: 'foobar', scopes: ['source.asciidoc']
+
+  it 'start with TIP:', ->
+    {tokens} = grammar.tokenizeLine 'TIP: Pro tip...'
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toEqual value: 'TIP:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[2]).toEqual value: 'Pro tip...', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+
+  it 'start with IMPORTANT:', ->
+    {tokens} = grammar.tokenizeLine 'IMPORTANT: Don\'t forget...'
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toEqual value: 'IMPORTANT:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[2]).toEqual value: 'Don\'t forget...', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+
+  it 'start with WARNING:', ->
+    {tokens} = grammar.tokenizeLine 'WARNING: Watch out for...'
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toEqual value: 'WARNING:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[2]).toEqual value: 'Watch out for...', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+
+  it 'start with CAUTION:', ->
+    {tokens} = grammar.tokenizeLine 'CAUTION: Ensure that...'
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toEqual value: 'CAUTION:', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'support.constant.label.asciidoc']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
+    expect(tokens[2]).toEqual value: 'Ensure that...', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']


### PR DESCRIPTION
## Description

Admonition multi-lines support.

## Syntax example

```asciidoc
foobar

NOTE: An admonition paragraph draws the reader's attention to
auxiliary information.
Its purpose is *determined* by the label
at the _beginning_ of the paragraph.

Here are the other built-in admonition types:

TIP: a *pro* _tip_...

IMPORTANT: Don't *forget* icon:megaphone[]

WARNING: Watch out for...

CAUTION: Ensure that...
```

## Screenshots

![capture du 2016-05-03 01-12-49](https://cloud.githubusercontent.com/assets/5674651/14970792/2c8c062c-10cc-11e6-80dc-d99e6ada70ec.png)
