### PR TITLE
Add line break support

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -42,6 +42,9 @@ patterns: [
   {
     include: "#inlines"
   }
+  {
+    include: "#line-break"
+  }
 ]
 repository:
   blocks:
@@ -229,6 +232,15 @@ repository:
       {
         name: "constant.other.symbol.horizontal-rule.asciidoc"
         match: "^(?:'|<){3,}$|^ {0,3}([-\\*'])( *)\\1\\2\\1$"
+      }
+    ]
+  "line-break":
+    patterns: [
+      {
+        match: "\\p{Blank}(\\+)$"
+        captures:
+          "1":
+            name: "variable.line-break.asciidoc"
       }
     ]
   list:

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -27,6 +27,8 @@ patterns: [
   include: '#blocks'
 ,
   include: '#inlines'
+,
+  include: '#line-break'
 ]
 repository:
   blocks:

--- a/grammars/repositories/partials/line-break-grammar.cson
+++ b/grammars/repositories/partials/line-break-grammar.cson
@@ -1,0 +1,16 @@
+key: 'line-break'
+
+patterns: [
+
+  # Matches a trailing + preceded by at least one space character,
+  # which forces a hard line break (<br> tag in HTML outputs).
+  #
+  # Examples
+  #
+  #    +
+  #   Foo +
+  #
+  match: '\\p{Blank}(\\+)$'
+  captures:
+    1: name: 'variable.line-break.asciidoc'
+]

--- a/spec/partials/line-break-grammar-spec.coffee
+++ b/spec/partials/line-break-grammar-spec.coffee
@@ -1,0 +1,41 @@
+describe 'Should tokenize line break when', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  # convenience function during development
+  debug = (tokens) ->
+    console.log(JSON.stringify tokens, null, ' ')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  it 'contains simple character', ->
+    tokens = grammar.tokenizeLines '''
+       +
+      Foo +
+      '''
+    expect(tokens).toHaveLength 2
+    expect(tokens[0]).toHaveLength 2
+    expect(tokens[0][0]).toEqual value: ' ', scopes: ['source.asciidoc']
+    expect(tokens[0][1]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']
+    expect(tokens[1]).toHaveLength 3
+    expect(tokens[1][0]).toEqual value: 'Foo', scopes: ['source.asciidoc']
+    expect(tokens[1][1]).toEqual value: ' ', scopes: ['source.asciidoc']
+    expect(tokens[1][2]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']
+
+  it 'ending with strong', ->
+    {tokens} = grammar.tokenizeLine 'Rubies are *red* +'
+    expect(tokens).toHaveLength 6
+    expect(tokens[0]).toEqual value: 'Rubies are ', scopes: ['source.asciidoc']
+    expect(tokens[1]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[2]).toEqual value: 'red', scopes: ['source.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[3]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.asciidoc']
+    expect(tokens[5]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']


### PR DESCRIPTION
## Description

Add line break support.

## Syntax example

```asciidoc
 +
Foo +

Rubies are *red* +
_Topazes_ are blue.

[%hardbreaks]
Ruby is red.
Java is black.
```

## Screenshots

![capture du 2016-05-03 01-15-03](https://cloud.githubusercontent.com/assets/5674651/14970818/7bdf3a78-10cc-11e6-95b6-ce82b4153a14.png)

## Issues

Fix #42