### PR TITLE
feat: header level distinction

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -215,14 +215,94 @@ repository:
   titles:
     patterns: [
       {
-        name: "markup.heading.asciidoc"
-        begin: "^((?:=|#){1,6})([\\p{Blank}]+)(?=\\S+)"
+        name: "markup.heading-5.asciidoc"
+        begin: "^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)"
+        end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
         patterns: [
           {
             include: "$self"
           }
         ]
+      }
+      {
+        name: "markup.heading-4.asciidoc"
+        begin: "^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        name: "markup.heading-3.asciidoc"
+        begin: "^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)"
+        end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        name: "markup.heading-2.asciidoc"
+        begin: "^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)"
+        end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        name: "markup.heading-1.asciidoc"
+        begin: "^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)"
+        end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        name: "markup.heading-0.asciidoc"
+        begin: "^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)"
+        end: "$"
+        captures:
+          "1":
+            name: "markup.heading.marker.asciidoc"
+          "2":
+            name: "markup.heading.space.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
       }
     ]
   various:

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -218,7 +218,7 @@ repository:
         name: "markup.heading-5.asciidoc"
         begin: "^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":
@@ -233,7 +233,7 @@ repository:
         name: "markup.heading-4.asciidoc"
         begin: "^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":
@@ -248,7 +248,7 @@ repository:
         name: "markup.heading-3.asciidoc"
         begin: "^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":
@@ -263,7 +263,7 @@ repository:
         name: "markup.heading-2.asciidoc"
         begin: "^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":
@@ -278,7 +278,7 @@ repository:
         name: "markup.heading-1.asciidoc"
         begin: "^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":
@@ -293,7 +293,7 @@ repository:
         name: "markup.heading-0.asciidoc"
         begin: "^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
-        captures:
+        beginCaptures:
           "1":
             name: "markup.heading.marker.asciidoc"
           "2":

--- a/grammars/repositories/partials/titles-grammar.cson
+++ b/grammars/repositories/partials/titles-grammar.cson
@@ -2,20 +2,99 @@ key: 'titles'
 
 patterns: [
 
-  # Matches section titles (headers)
+  # Matches level 5 section titles (headers)
   #
-  # Examples
+  # Example
   #
-  #   = Document Title (Level 0)
+  #   ====== Level 5 Section
   #
-  #   == Level 1 Section
-  #
-  #   === Level 2 Section
-  #
-  name: 'markup.heading.asciidoc'
-  begin: '^((?:=|#){1,6})([\\p{Blank}]+)(?=\\S+)'
+  name: 'markup.heading-5.asciidoc'
+  begin: '^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)'
+  end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
   patterns: [
     include: '$self'
   ]
+,
+  # Matches level 4 section titles (headers)
+  #
+  # Example
+  #
+  #   ===== Level 4 Section
+  #
+  name: 'markup.heading-4.asciidoc'
+  begin: '^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
+,
+  # Matches level 3 section titles (headers)
+  #
+  # Example
+  #
+  #   ==== Level 3 Section
+  #
+  name: 'markup.heading-3.asciidoc'
+  begin: '^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)'
+  end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
+,
+  # Matches level 2 section titles (headers)
+  #
+  # Example
+  #
+  #   === Level 2 Section
+  #
+  name: 'markup.heading-2.asciidoc'
+  begin: '^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)'
+  end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
+,
+  # Matches level 1 section titles (headers)
+  #
+  # Example
+  #
+  #   == Level 1 Section
+  #
+  name: 'markup.heading-1.asciidoc'
+  begin: '^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)'
+  end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
+,
+  # Matches level 0 section titles (headers)
+  #
+  # Example
+  #
+  #   = Document Title (Level 0)
+  #
+  name: 'markup.heading-0.asciidoc'
+  begin: '^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)'
+  end: '$'
+  captures:
+    1: name: 'markup.heading.marker.asciidoc'
+    2: name: 'markup.heading.space.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
 ]

--- a/grammars/repositories/partials/titles-grammar.cson
+++ b/grammars/repositories/partials/titles-grammar.cson
@@ -11,7 +11,7 @@ patterns: [
   name: 'markup.heading-5.asciidoc'
   begin: '^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [
@@ -27,7 +27,7 @@ patterns: [
   name: 'markup.heading-4.asciidoc'
   begin: '^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [
@@ -43,7 +43,7 @@ patterns: [
   name: 'markup.heading-3.asciidoc'
   begin: '^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [
@@ -59,7 +59,7 @@ patterns: [
   name: 'markup.heading-2.asciidoc'
   begin: '^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [
@@ -75,7 +75,7 @@ patterns: [
   name: 'markup.heading-1.asciidoc'
   begin: '^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [
@@ -91,7 +91,7 @@ patterns: [
   name: 'markup.heading-0.asciidoc'
   begin: '^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
-  captures:
+  beginCaptures:
     1: name: 'markup.heading.marker.asciidoc'
     2: name: 'markup.heading.space.asciidoc'
   patterns: [

--- a/spec/partials/titles-grammar-spec.coffee
+++ b/spec/partials/titles-grammar-spec.coffee
@@ -16,51 +16,30 @@ describe 'Titles', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  describe 'description', ->
+  describe 'asciidoc headers', ->
 
     asciidocHeadersChecker = (level) ->
       equalsSigns = level + 1
       marker = Array(equalsSigns + 1).join('=')
       {tokens} = grammar.tokenizeLine "#{marker} Heading #{level}"
-      expect(tokens[0]).toEqual value: "#{marker} ", scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: "Heading #{level}", scopes: ['source.asciidoc', 'markup.heading.asciidoc']
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqual value: "#{marker}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
+      expect(tokens[1]).toEqual value: " ", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
+      expect(tokens[2]).toEqual value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc"]
 
     it 'tokenizes AsciiDoc-style headings', ->
       asciidocHeadersChecker(level) for level in [0..5]
 
-  describe 'Should tokenizes Mardown-style headings when', ->
+  describe 'markdown headers', ->
 
-    it 'was a level 0', ->
-      {tokens} = grammar.tokenizeLine '# Heading 0'
-      expect(tokens).toHaveLength 2
-      expect(tokens[0]).toEqual value: '# ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 0', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
+    markdownHeadersChecker = (level) ->
+      equalsSigns = level + 1
+      marker = Array(equalsSigns + 1).join('#')
+      {tokens} = grammar.tokenizeLine "#{marker} Heading #{level}"
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqual value: "#{marker}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
+      expect(tokens[1]).toEqual value: " ", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
+      expect(tokens[2]).toEqual value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc"]
 
-    it 'was a level 1', ->
-      {tokens} = grammar.tokenizeLine '## Heading 1'
-      expect(tokens).toHaveLength 2
-      expect(tokens[0]).toEqual value: '## ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 1', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-
-    it 'was a level 2', ->
-      {tokens} = grammar.tokenizeLine '### Heading 2'
-      expect(tokens).toHaveLength 2
-      expect(tokens[0]).toEqual value: '### ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 2', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-
-    it 'was a level 3', ->
-      {tokens} = grammar.tokenizeLine '#### Heading 3'
-      expect(tokens).toHaveLength 2
-      expect(tokens[0]).toEqual value: '#### ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 3', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-
-    it 'was a level 4', ->
-      {tokens} = grammar.tokenizeLine '##### Heading 4'
-      expect(tokens[0]).toEqual value: '##### ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 4', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-
-    it 'was a level 5', ->
-      {tokens} = grammar.tokenizeLine '###### Heading 5'
-      expect(tokens).toHaveLength 2
-      expect(tokens[0]).toEqual value: '###### ', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
-      expect(tokens[1]).toEqual value: 'Heading 5', scopes: ['source.asciidoc', 'markup.heading.asciidoc']
+    it 'tokenizes Markdown-style headings', ->
+      markdownHeadersChecker(level) for level in [0..5]

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -37,7 +37,12 @@ atom-text-editor, :host {
 
       &.admonition,
       &.explicit,
-      &.heading,
+      &.heading-0,
+      &.heading-1,
+      &.heading-2,
+      &.heading-3,
+      &.heading-4,
+      &.heading-5,
       &.section {
         font-weight: bold;
 


### PR DESCRIPTION
This feature distinguishes headers into their separate levels (0-5). this enables custom styling in the future. This feature mirrors the naming used in the GitHub flavored Markdown (GFM) language package.

On this visual side this feature changes nothing, it's just creating potential.