### PR TITLE
🚀 Grammar live reload 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 sudo: false
 
+git:
+  depth: 10
+
+branches:
+  only:
+    - master
+
 os:
   - linux
   - osx

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -77,7 +77,7 @@ sh build-package.sh
 
 .Testing syntax
 * http://flight-manual.atom.io/hacking-atom/sections/writing-specs[Atom specs]
-* http://jasmine.github.io/edge/introduction.html[Jasmine]
+* http://jasmine.github.io/1.3/introduction.html[Jasmine 1.3]
 
 == Grammar
 
@@ -94,10 +94,19 @@ The file link:grammars/language-asciidoc.cson[grammars/language-asciidoc.cson] i
 atom -d .
 ----
 
-* Open the command dialog with press keys: `Ctrl+Shift-P`
-* In the command dialog, find and choose the item named `Asciidoc Grammar: Compile grammar and reload`
-** Tips: write only `AG` for a quick access to the item.
+* Open the Command Palette with press keys: `Ctrl+Shift-P`
+* In the Command Palette, find and choose the item named `Asciidoc Grammar: Compile grammar and reload`
+** Tips: write only `agc` for a quick access to the item.
 * The grammar file is re-generated automatically.
+
+==== Live Reload
+
+* For automaticaly reload the grammar when a `.cson` file is saved:
+** In the package settings, checked: `[Only on Developer Mode] Grammars live reload`
+** To quickly toggle Live Reload:
+*** Open the Command Palette with press keys: `Ctrl+Shift-P`
+*** In the Command Palette, find and choose the item named `Asciidoc Grammar: Toggle Live Reload`
+**** Tips: write only `agt` for a quick access to the item.
 
 === Language definition
 

--- a/lib/grammar-helper.coffee
+++ b/lib/grammar-helper.coffee
@@ -13,7 +13,7 @@ class GrammarHelper
     CSON.readFileSync filepath
 
   writeGrammarFile: (grammar, file) ->
-    outputFilepath = path.join __dirname,  @rootOutputDirectory, file
+    outputFilepath = path.join __dirname, @rootOutputDirectory, file
     CSON.writeFileSync outputFilepath, grammar
 
   appendPartialGrammars: (grammar, partialGrammarFiles) ->
@@ -25,11 +25,11 @@ class GrammarHelper
 
   appendPartialGrammarsDirectory: (grammar, grammarDirectories) ->
     for directoryName in grammarDirectories
-      directory = new Directory(path.join(__dirname, @rootInputDirectory, directoryName))
+      directory = new Directory path.join(__dirname, @rootInputDirectory, directoryName)
       entries = directory.getEntriesSync()
       for entry in entries
-        if (entry.isFile() and entry.getBaseName().endsWith '.cson')
-          {key, patterns} = CSON.readFileSync(entry.path)
+        if entry.isFile() and entry.getBaseName().endsWith '.cson'
+          {key, patterns} = CSON.readFileSync entry.path
           if key? and patterns?
             grammar.repository[key] =
               patterns: patterns

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,50 +2,101 @@
 CSON = require 'season'
 GrammarHelper = require './grammar-helper'
 generator = require './code-block-generator'
+path = require 'path'
 
 module.exports =
 
+  config:
+    liveReload:
+      title: '[Only on Developer Mode] Grammars live reload'
+      type: 'boolean'
+      default: false
+
   subscriptions: null
+  liveReloadSubscriptions: null
 
   activate: (state) ->
-    @subscriptions = new CompositeDisposable()
+    return unless atom.inDevMode() and not atom.inSpecMode()
 
-    if atom.inDevMode()
-      @subscriptions.add atom.commands.add 'atom-workspace', 'asciidoc-grammar:compile-grammar-and-reload': => @compileGrammar()
+    @subscriptions = new CompositeDisposable
+
+    @helper = new GrammarHelper '../grammars/repositories/', '../grammars/'
+
+    # Add actions in Command Palette
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'asciidoc-grammar:compile-grammar-and-reload': => @compileGrammar()
+      'asciidoc-grammar:toggle-live-reload': ->
+        keyPath = 'language-asciidoc.liveReload'
+        atom.config.set(keyPath, not atom.config.get(keyPath))
+
+    # Calls immediately and every time the value is changed
+    @subscriptions.add atom.config.observe 'language-asciidoc.liveReload', (newValue) =>
+      if newValue
+        @compileGrammar()
+        @liveReloadSubscriptions = new CompositeDisposable
+        @startliveReload()
+      else
+        @liveReloadSubscriptions?.dispose()
+
+  startliveReload: ->
+    return unless atom.inDevMode() and not atom.inSpecMode() and atom.config.get 'language-asciidoc.liveReload'
+
+    @liveReloadSubscriptions.add atom.workspace.observeTextEditors (editor) =>
+      if path.extname(editor.getTitle()) is '.cson'
+        @liveReloadSubscriptions.add editor.buffer.onDidSave =>
+          @compileGrammar()
 
   compileGrammar: (debug) ->
-    if atom.inDevMode()
+    return unless atom.inDevMode() and not atom.inSpecMode()
 
-      helper = new GrammarHelper('../grammars/repositories/', '../grammars/')
+    rootGrammar = @helper.readGrammarFile 'asciidoc-grammar.cson'
+    rootGrammar.name = 'AsciiDoc'
+    rootGrammar.scopeName = 'source.asciidoc'
+    rootGrammar.fileTypes = [
+      'ad'
+      'asc'
+      'adoc'
+      'asciidoc'
+      'adoc.txt'
+    ]
 
-      rootGrammar = helper.readGrammarFile 'asciidoc-grammar.cson'
-      rootGrammar.name = 'AsciiDoc'
-      rootGrammar.scopeName = 'source.asciidoc'
-      rootGrammar.fileTypes = [
-        'ad'
-        'asc'
-        'adoc'
-        'asciidoc'
-        'adoc.txt'
-      ]
+    @helper.appendPartialGrammarsDirectory rootGrammar, ['partials/', 'inlines/', 'blocks/']
 
-      helper.appendPartialGrammarsDirectory rootGrammar, ['partials/', 'inlines/', 'blocks/']
+    # Load languages list
+    languages = @helper.readGrammarFile 'languages.cson'
 
-      # Load languages list
-      languages = helper.readGrammarFile 'languages.cson'
+    # Add languages blocks for AsciiDoc
+    codeAsciidocBlocks = generator.makeAsciidocBlocks languages
+    rootGrammar.repository['source-asciidoctor'] = patterns: codeAsciidocBlocks
 
-      # Add languages blocks for AsciiDoc
-      codeAsciidocBlocks = generator.makeAsciidocBlocks languages
-      rootGrammar.repository['source-asciidoctor'] = patterns: codeAsciidocBlocks
+    # Add languages blocks for Markdown
+    codeMarkdownBlocks = generator.makeMarkdownBlocks languages
+    rootGrammar.repository['source-markdown'] = patterns: codeMarkdownBlocks
 
-      # Add languages blocks for Markdown
-      codeMarkdownBlocks = generator.makeMarkdownBlocks languages
-      rootGrammar.repository['source-markdown'] = patterns: codeMarkdownBlocks
+    if debug
+      console.log CSON.stringify rootGrammar
+    @helper.writeGrammarFile rootGrammar, 'language-asciidoc.cson'
+    @reload()
 
-      if debug
-        console.log CSON.stringify rootGrammar
-      helper.writeGrammarFile rootGrammar, 'language-asciidoc.cson', do ->
-        atom.commands.dispatch 'body', 'window:reload'
+  reload: ->
+    # Remove grammars
+    atom.grammars.removeGrammarForScopeName 'source.asciidoc'
+    atom.grammars.removeGrammarForScopeName 'source.asciidoc.properties'
+
+    # Remove loaded package (Hack force reload)
+    delete atom.packages.loadedPackages['language-asciidoc']
+
+    # Load package
+    updatedPackage = atom.packages.loadPackage 'language-asciidoc'
+    updatedPackage.loadGrammarsSync()
+
+    # Reload grammars for each editor
+    atom.workspace.getTextEditors().forEach (editor) ->
+      if editor.getGrammar().packageName is 'language-asciidoc'
+        editor.reloadGrammar()
+
+    console.log 'AsciiDoc grammars reloaded'
 
     deactivate: ->
+      @liveReloadSubscriptions?.dispose()
       @subscriptions.dispose()

--- a/spec/code-block-generator-spec.coffee
+++ b/spec/code-block-generator-spec.coffee
@@ -1,8 +1,8 @@
 generator = require '../lib/code-block-generator'
 
-describe "Code block generator", ->
+describe 'Code block generator', ->
 
-  describe "with AsciiDoc syntax", ->
+  describe 'with AsciiDoc syntax', ->
 
     it 'should generate default code block', ->
       languages = []
@@ -78,7 +78,7 @@ describe "Code block generator", ->
           ]
         ]
 
-  describe "with Markdown syntax", ->
+  describe 'with Markdown syntax', ->
 
     it 'should generate default code block', ->
       languages = []

--- a/spec/grammar-helper-spec.coffee
+++ b/spec/grammar-helper-spec.coffee
@@ -1,15 +1,22 @@
 GrammarHelper = require '../lib/grammar-helper'
 
-describe "Grammar helper", ->
+describe 'Grammar helper', ->
 
-  helper = null
-
-  beforeEach ->
-    helper = new GrammarHelper('../spec/fixtures/grammars/', '../spec/output/')
+  helper = new GrammarHelper('../spec/fixtures/grammars/', '../spec/output/')
 
   it 'should create a grammar object when read a grammar file', ->
     fileContent = helper.readGrammarFile 'sample01.cson'
-    expect(fileContent.key).toEqual 'test'
-    expect(fileContent.patterns).toHaveLength 2
-    expect(fileContent.patterns[0]).toEqual 'foo'
-    expect(fileContent.patterns[1]).toEqual 'bar'
+
+    expect(fileContent).toEqualJson key: 'test', patterns: ['foo', 'bar']
+
+  it 'should append file content to existing grammar when read a partial grammar file', ->
+    grammar =
+      repository: {}
+
+    partialGrammarFiles = [
+      'sample01.cson'
+    ]
+
+    helper.appendPartialGrammars grammar, partialGrammarFiles
+
+    expect(grammar).toEqualJson repository: test: patterns: ['foo', 'bar']


### PR DESCRIPTION
In Dev Mode, edit grammars `.cson` files and immediately see the changes in `.adoc` files.  :dizzy:  :sparkles:

- No longer white flash when compile grammar.