### PR TITLE
correct monospaced phrase matches

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -434,11 +434,11 @@ repository:
     patterns: [
       {
         name: "markup.raw.constrained.monospaced.asciidoc"
-        match: "(^|[^\\p{Word};:\"'`}])(?:\\[([^\\]]+?)\\])?`(\\S|\\S.*?\\S)`(?![\\p{Word}\"'`])"
+        match: "(?<![\\\\;:\\p{Word}\"'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}\"'`])"
       }
       {
         name: "markup.raw.unconstrained.monospaced.asciidoc"
-        match: "\\\\?(?:\\[([^\\]]+?)\\])?``(.+?)``"
+        match: "(?<!\\\\)(?:\\[.+?\\])?``(?:.+?)``"
       }
     ]
   "passthrough-macro":

--- a/grammars/repositories/inlines/monospaced-grammar.cson
+++ b/grammars/repositories/inlines/monospaced-grammar.cson
@@ -9,7 +9,7 @@ patterns: [
   #   `Text in backticks` renders exactly as entered, in `monospaced`.
   #
   name: 'markup.raw.constrained.monospaced.asciidoc'
-  match: '(^|[^\\p{Word};:"\'`}])(?:\\[([^\\]]+?)\\])?`(\\S|\\S.*?\\S)`(?![\\p{Word}"\'`])'
+  match: '(?<![\\\\;:\\p{Word}"\'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}"\'`])'
 ,
   # Matches unconstrained monospaced inlines
   #
@@ -18,5 +18,5 @@ patterns: [
   #   Text in back``ticks`` renders exactly as entered, in mono``spaced``.
   #
   name: 'markup.raw.unconstrained.monospaced.asciidoc'
-  match: '\\\\?(?:\\[([^\\]]+?)\\])?``(.+?)``'
+  match: '(?<!\\\\)(?:\\[.+?\\])?``(?:.+?)``'
 ]

--- a/spec/inlines/monospaced-grammar-spec.coffee
+++ b/spec/inlines/monospaced-grammar-spec.coffee
@@ -22,8 +22,8 @@ describe '`monospaced`', ->
       {tokens} = grammar.tokenizeLine '`Text in backticks` renders exactly as entered, in `monospaced`.'
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toEqual value: '`Text in backticks`', scopes: ['source.asciidoc', 'markup.raw.constrained.monospaced.asciidoc']
-      expect(tokens[1]).toEqual value: ' renders exactly as entered, in', scopes: ['source.asciidoc']
-      expect(tokens[2]).toEqual value: ' `monospaced`', scopes: ['source.asciidoc', 'markup.raw.constrained.monospaced.asciidoc']
+      expect(tokens[1]).toEqual value: ' renders exactly as entered, in ', scopes: ['source.asciidoc']
+      expect(tokens[2]).toEqual value: '`monospaced`', scopes: ['source.asciidoc', 'markup.raw.constrained.monospaced.asciidoc']
       expect(tokens[3]).toEqual value: '.', scopes: ['source.asciidoc']
 
     it 'is not in valid context', ->


### PR DESCRIPTION
- don't capture preceding character
- don't match escaped monospaced pattern
- simply match for attribute list
- use non-capturing groups