### PR TITLE
doc: no compat mode supported

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -141,6 +141,13 @@ You can check the available source languages available in your Atom editor, to s
 .Example language query
 image::https://cloud.githubusercontent.com/assets/5674651/14895946/a40b08aa-0d7b-11e6-9bff-458a3d42087c.png[screenshot of a code support query]
 
+
+== Compatibility mode not supported
+As the AsciiDoc syntax has changed quite a bit since the original Python implementation, Asciidoctor offers a legacy mode called `compat-mode`. This mode can be set using the `:compat-mode:` attribute. This can be done in the document iteself, or when generating the final result using `asciidoctor -a compat-mode`, or it's shorter equivalent `asciidoc`.
+
+As the compatibility mode is a legacy syntax the project wants to move away from, the mode can be triggered from outside the source itself, and changing grammar on the fly introduces complexity, *compatibility mode is currently not supported by this highlighter*.
+
+
 == Styling
 
 The styling is defined in link:styles/asciidoc.atom-text-editor.less[styles/asciidoc.atom-text-editor.less]


### PR DESCRIPTION
As discussed in pull request no 4, introducing compatibility mode is not recommended. This technical decision is now documented in the Contributing guidelines.