### PR TITLE
Heading style

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -282,7 +282,7 @@ repository:
   titles:
     patterns: [
       {
-        name: "markup.heading-5.asciidoc"
+        name: "markup.heading.heading-5.asciidoc"
         begin: "^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:
@@ -297,7 +297,7 @@ repository:
         ]
       }
       {
-        name: "markup.heading-4.asciidoc"
+        name: "markup.heading.heading-4.asciidoc"
         begin: "^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:
@@ -312,7 +312,7 @@ repository:
         ]
       }
       {
-        name: "markup.heading-3.asciidoc"
+        name: "markup.heading.heading-3.asciidoc"
         begin: "^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:
@@ -327,7 +327,7 @@ repository:
         ]
       }
       {
-        name: "markup.heading-2.asciidoc"
+        name: "markup.heading.heading-2.asciidoc"
         begin: "^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:
@@ -342,7 +342,7 @@ repository:
         ]
       }
       {
-        name: "markup.heading-1.asciidoc"
+        name: "markup.heading.heading-1.asciidoc"
         begin: "^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:
@@ -357,7 +357,7 @@ repository:
         ]
       }
       {
-        name: "markup.heading-0.asciidoc"
+        name: "markup.heading.heading-0.asciidoc"
         begin: "^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)"
         end: "$"
         beginCaptures:

--- a/grammars/repositories/partials/titles-grammar.cson
+++ b/grammars/repositories/partials/titles-grammar.cson
@@ -8,7 +8,7 @@ patterns: [
   #
   #   ====== Level 5 Section
   #
-  name: 'markup.heading-5.asciidoc'
+  name: 'markup.heading.heading-5.asciidoc'
   begin: '^((?:=|#){6})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:
@@ -24,7 +24,7 @@ patterns: [
   #
   #   ===== Level 4 Section
   #
-  name: 'markup.heading-4.asciidoc'
+  name: 'markup.heading.heading-4.asciidoc'
   begin: '^((?:=|#){5})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:
@@ -40,7 +40,7 @@ patterns: [
   #
   #   ==== Level 3 Section
   #
-  name: 'markup.heading-3.asciidoc'
+  name: 'markup.heading.heading-3.asciidoc'
   begin: '^((?:=|#){4})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:
@@ -56,7 +56,7 @@ patterns: [
   #
   #   === Level 2 Section
   #
-  name: 'markup.heading-2.asciidoc'
+  name: 'markup.heading.heading-2.asciidoc'
   begin: '^((?:=|#){3})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:
@@ -72,7 +72,7 @@ patterns: [
   #
   #   == Level 1 Section
   #
-  name: 'markup.heading-1.asciidoc'
+  name: 'markup.heading.heading-1.asciidoc'
   begin: '^((?:=|#){2})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:
@@ -88,7 +88,7 @@ patterns: [
   #
   #   = Document Title (Level 0)
   #
-  name: 'markup.heading-0.asciidoc'
+  name: 'markup.heading.heading-0.asciidoc'
   begin: '^((?:=|#){1})([\\p{Blank}]+)(?=\\S+)'
   end: '$'
   beginCaptures:

--- a/spec/partials/titles-grammar-spec.coffee
+++ b/spec/partials/titles-grammar-spec.coffee
@@ -1,3 +1,5 @@
+# To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
+# or `fdescribe`). Remove the `f` to unfocus the block.
 describe 'Titles', ->
   grammar = null
 
@@ -23,9 +25,9 @@ describe 'Titles', ->
       marker = Array(equalsSigns + 1).join('=')
       {tokens} = grammar.tokenizeLine "#{marker} Heading #{level}"
       expect(tokens).toHaveLength 3
-      expect(tokens[0]).toEqual value: "#{marker}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
-      expect(tokens[1]).toEqual value: " ", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
-      expect(tokens[2]).toEqual value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc"]
+      expect(tokens[0]).toEqualJson value: "#{marker}", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
+      expect(tokens[1]).toEqualJson value: " ", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
+      expect(tokens[2]).toEqualJson value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc"]
 
     it 'tokenizes AsciiDoc-style headings', ->
       asciidocHeadersChecker(level) for level in [0..5]
@@ -37,9 +39,9 @@ describe 'Titles', ->
       marker = Array(equalsSigns + 1).join('#')
       {tokens} = grammar.tokenizeLine "#{marker} Heading #{level}"
       expect(tokens).toHaveLength 3
-      expect(tokens[0]).toEqual value: "#{marker}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
-      expect(tokens[1]).toEqual value: " ", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
-      expect(tokens[2]).toEqual value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading-#{level}.asciidoc"]
+      expect(tokens[0]).toEqualJson value: "#{marker}", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc", 'markup.heading.marker.asciidoc']
+      expect(tokens[1]).toEqualJson value: " ", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc", 'markup.heading.space.asciidoc']
+      expect(tokens[2]).toEqualJson value: "Heading #{level}", scopes: ['source.asciidoc', "markup.heading.heading-#{level}.asciidoc"]
 
     it 'tokenizes Markdown-style headings', ->
       markdownHeadersChecker(level) for level in [0..5]

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -37,6 +37,7 @@ atom-text-editor, :host {
 
       &.admonition,
       &.explicit,
+      &.heading,
       &.heading-0,
       &.heading-1,
       &.heading-2,


### PR DESCRIPTION
The recent changes breaks the heading style with some theme.

Currently (dev mode):
![capture du 2016-05-07 16-45-56](https://cloud.githubusercontent.com/assets/5674651/15092780/f22ab64e-1473-11e6-99de-0530d95798f7.png)

With my changes:
![capture du 2016-05-07 16-46-26](https://cloud.githubusercontent.com/assets/5674651/15092781/f22da3b8-1473-11e6-817c-433ab394052f.png)

I have try with several themes.