### PR TITLE
doc: file ext support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ Adds syntax highlighting and snippets to AsciiDoc files. Supports [Asciidoctor](
 
 ![](https://raw.github.com/wiki/asciidoctor/atom-language-asciidoc/writers-guide-screenshot.png)
 
+## File extension support
+
+The default file extensions for AsciiDoc files are _ad_, _asc_, _adoc_, _asciidoc_, and _asciidoc.txt_
+Changing the file extension to _asciidoc.txt_ is a recommended solution to remain compatibile with _.txt_ based tooling, whilst having a distinct filename related to the AsciiDoc language.
+To add a different file extension, such at _.txt_, customize your Atom configuration:
+
+Open the Atom configuration:
+* Menu > _Edit_ > _Config.._
+* 'Application: open your config' via the Command Palette
+* Edit `~/.atom/config.cson`
+
+Add a custom file type support:
+```coffee
+  core:
+    ...
+    customFileTypes:
+      "source.asciidoc": [
+          "foo" # all files with `.foo` extension (ex: `documentation.foo`)
+          "foobar.txt" # all files with `.foobar.txt` extension  (ex `documentation.foobar.txt`)
+      ]
+    ...
+```
+
+Then save the configuration file and restart Atom or press `ctrl+alt+r` to refresh the UI.  You should now see the new file type recognized by the atom-language-asciidoc package.
+
 ## Contributing
 
 In the spirit of free software, _everyone_ is encouraged to help improve this project.


### PR DESCRIPTION
To summarize the discussion in PR #70, where the explicit info on the .txt support is desired, but the recommended customization is through the Atom config, rather than through the Grammar modification.

Credits go to @bwklein and @ldez 