### PR TITLE
make hard line break match more strict

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -237,7 +237,7 @@ repository:
   "line-break":
     patterns: [
       {
-        match: "\\p{Blank}(\\+)$"
+        match: "(?<=\\S)\\p{Blank}+(\\+)$"
         captures:
           "1":
             name: "variable.line-break.asciidoc"

--- a/grammars/repositories/partials/line-break-grammar.cson
+++ b/grammars/repositories/partials/line-break-grammar.cson
@@ -2,15 +2,16 @@ key: 'line-break'
 
 patterns: [
 
-  # Matches a trailing + preceded by at least one space character,
-  # which forces a hard line break (<br> tag in HTML outputs).
+  # Matches a trailing + preceded by at least one space character
+  # at the end of a line of non-empty content, which forces a
+  # hard line break (<br> tag in HTML output).
   #
   # Examples
   #
-  #    +
   #   Foo +
+  #   Bar
   #
-  match: '\\p{Blank}(\\+)$'
+  match: '(?<=\\S)\\p{Blank}+(\\+)$'
   captures:
     1: name: 'variable.line-break.asciidoc'
 ]

--- a/spec/partials/line-break-grammar-spec.coffee
+++ b/spec/partials/line-break-grammar-spec.coffee
@@ -18,17 +18,16 @@ describe 'Should tokenize line break when', ->
 
   it 'contains simple character', ->
     tokens = grammar.tokenizeLines '''
-       +
       Foo +
+      Bar
       '''
     expect(tokens).toHaveLength 2
-    expect(tokens[0]).toHaveLength 2
-    expect(tokens[0][0]).toEqual value: ' ', scopes: ['source.asciidoc']
-    expect(tokens[0][1]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']
-    expect(tokens[1]).toHaveLength 3
-    expect(tokens[1][0]).toEqual value: 'Foo', scopes: ['source.asciidoc']
-    expect(tokens[1][1]).toEqual value: ' ', scopes: ['source.asciidoc']
-    expect(tokens[1][2]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']
+    expect(tokens[0]).toHaveLength 3
+    expect(tokens[0][0]).toEqual value: 'Foo', scopes: ['source.asciidoc']
+    expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.asciidoc']
+    expect(tokens[0][2]).toEqual value: '+', scopes: ['source.asciidoc', 'variable.line-break.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqual value: 'Bar', scopes: ['source.asciidoc']
 
   it 'ending with strong', ->
     {tokens} = grammar.tokenizeLine 'Rubies are *red* +'


### PR DESCRIPTION
Require that the line have at least one non-blank character before the line break syntax.