### PR TITLE
resolves #43 support text formatting in footnote content

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -450,11 +450,18 @@ repository:
   "footnote-macro":
     patterns: [
       {
-        name: "markup.link.footnote.asciidoc"
-        match: "\\\\?(footnote(?:ref)?):\\[(.*?[^\\\\])\\]"
+        name: "markup.other.footnote.asciidoc"
+        match: "(?<!\\\\)(footnote(?:ref)?):\\[(.*?[^\\\\])\\]"
         captures:
+          "1":
+            name: "entity.name.function.asciidoc"
           "2":
-            name: "support.constant.footnote.inline.asciidoc"
+            name: "string.unquoted.asciidoc"
+            patterns: [
+              {
+                include: "#inlines"
+              }
+            ]
       }
     ]
   "general-block-macro":

--- a/grammars/repositories/inlines/footnote-macro-grammar.cson
+++ b/grammars/repositories/inlines/footnote-macro-grammar.cson
@@ -9,8 +9,13 @@ patterns: [
   #   footnoteref:[id,text]
   #   footnoteref:[id]
   #
-  name: 'markup.link.footnote.asciidoc'
-  match: '\\\\?(footnote(?:ref)?):\\[(.*?[^\\\\])\\]'
+  name: 'markup.other.footnote.asciidoc'
+  match: '(?<!\\\\)(footnote(?:ref)?):\\[(.*?[^\\\\])\\]'
   captures:
-    2: name: 'support.constant.footnote.inline.asciidoc'
+    1: name: 'entity.name.function.asciidoc'
+    2:
+      name: 'string.unquoted.asciidoc'
+      patterns: [
+        include: '#inlines'
+      ]
 ]

--- a/spec/inlines/footnote-macro-grammar-spec.coffee
+++ b/spec/inlines/footnote-macro-grammar-spec.coffee
@@ -18,21 +18,32 @@ describe 'Should tokenizes footnote macro when', ->
 
   it 'simple footnote', ->
     {tokens} = grammar.tokenizeLine 'footnote:[text]'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqual value: 'footnote:[', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
-    expect(tokens[1]).toEqual value: 'text', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc', 'support.constant.footnote.inline.asciidoc']
-    expect(tokens[2]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
+    expect(tokens).toHaveLength 4
+    expect(tokens[0]).toEqual value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[1]).toEqual value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    expect(tokens[2]).toEqual value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+
+  it 'simple footnote with formatted text', ->
+    {tokens} = grammar.tokenizeLine 'footnote:[*text*]'
+    expect(tokens).toHaveLength 6
+    expect(tokens[0]).toEqual value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[1]).toEqual value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    expect(tokens[3]).toEqual value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[5]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
 
   it 'simple footnoteref with id and text', ->
     {tokens} = grammar.tokenizeLine 'footnoteref:[id,text]'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqual value: 'footnoteref:[', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
-    expect(tokens[1]).toEqual value: 'id,text', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc', 'support.constant.footnote.inline.asciidoc']
-    expect(tokens[2]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
+    expect(tokens).toHaveLength 4
+    expect(tokens[0]).toEqual value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[1]).toEqual value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    expect(tokens[2]).toEqual value: 'id,text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
 
   it 'simple footnoteref with id', ->
     {tokens} = grammar.tokenizeLine 'footnoteref:[id]'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqual value: 'footnoteref:[', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
-    expect(tokens[1]).toEqual value: 'id', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc', 'support.constant.footnote.inline.asciidoc']
-    expect(tokens[2]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.link.footnote.asciidoc']
+    expect(tokens).toHaveLength 4
+    expect(tokens[0]).toEqual value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[1]).toEqual value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    expect(tokens[2]).toEqual value: 'id', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -76,6 +76,10 @@ atom-text-editor, :host {
           font-weight: bold;
       }
 
+      &.footnote {
+          color: @syntax-color-function;
+      }
+
       &.super {
         vertical-align: super;
         font-size: @font-size * .8;


### PR DESCRIPTION
- match inline patterns inside footnote content
- change name of match to markup.other.footnote.asciidoc
- skip escaped footnote
- add CSS for footnote (map to function color)