### PR TITLE
don't match strong phrase that is escaped

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -588,20 +588,20 @@ repository:
     patterns: [
       {
         name: "markup.bold.unconstrained.asciidoc"
-        match: "\\\\?(?:\\[([^\\]]+?)])?(\\*\\*)(.+?)(\\*\\*)"
+        match: "(?<!\\\\\\\\)(?:\\[.+?\\])?(\\*\\*).+?(\\*\\*)"
         captures:
-          "2":
+          "1":
             name: "support.constant.asciidoc"
-          "4":
+          "2":
             name: "support.constant.asciidoc"
       }
       {
         name: "markup.bold.constrained.asciidoc"
-        match: "(?<=^|[^\\p{Word};:}])(?:\\[([^\\]]+?)\\])?(\\*)(\\S|\\S.*?\\S)(\\*)(?!\\p{Word})"
+        match: "(?<![\\\\;:\\p{Word}\\*])(?:\\[.+?\\])?(\\*)(?:\\S|\\S.*?\\S)(\\*)(?!\\p{Word})"
         captures:
-          "2":
+          "1":
             name: "support.constant.asciidoc"
-          "4":
+          "2":
             name: "support.constant.asciidoc"
       }
     ]

--- a/grammars/repositories/inlines/strong-grammar.cson
+++ b/grammars/repositories/inlines/strong-grammar.cson
@@ -2,17 +2,17 @@ key: 'strong'
 
 patterns: [
 
-  # Matches bold unconstrained phrases
+  # Matches strong unconstrained phrases
   #
   # Examples
   #
-  #   b**old** phrase
+  #   **b**old character(s)
   #
   name: 'markup.bold.unconstrained.asciidoc'
-  match: '\\\\?(?:\\[([^\\]]+?)\])?(\\*\\*)(.+?)(\\*\\*)'
+  match: '(?<!\\\\\\\\)(?:\\[.+?\\])?(\\*\\*).+?(\\*\\*)'
   captures:
+    1: name: 'support.constant.asciidoc'
     2: name: 'support.constant.asciidoc'
-    4: name: 'support.constant.asciidoc'
 ,
   # Matches strong constrained phrases
   #
@@ -21,8 +21,8 @@ patterns: [
   #   *bold phrase*
   #
   name: 'markup.bold.constrained.asciidoc'
-  match: '(?<=^|[^\\p{Word};:}])(?:\\[([^\\]]+?)\\])?(\\*)(\\S|\\S.*?\\S)(\\*)(?!\\p{Word})'
+  match: '(?<![\\\\;:\\p{Word}\\*])(?:\\[.+?\\])?(\\*)(?:\\S|\\S.*?\\S)(\\*)(?!\\p{Word})'
   captures:
+    1: name: 'support.constant.asciidoc'
     2: name: 'support.constant.asciidoc'
-    4: name: 'support.constant.asciidoc'
 ]

--- a/spec/inlines/strong-grammar-spec.coffee
+++ b/spec/inlines/strong-grammar-spec.coffee
@@ -35,6 +35,11 @@ describe '*strong* text', ->
       expect(tokens[2]).toEqual value: '*', scopes: ['source.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
       expect(tokens[3]).toEqual value: ' from the start.', scopes: ['source.asciidoc']
 
+    it 'when constrained *strong* is escaped', ->
+      {tokens} = grammar.tokenizeLine '\\*strong text*'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqual value: '\\*strong text*', scopes: ['source.asciidoc']
+
     it 'when constrained *bold* in a * bulleted list', ->
       {tokens} = grammar.tokenizeLine '* *bold text* followed by normal text'
       expect(tokens).toHaveLength 6
@@ -157,6 +162,11 @@ describe '*strong* text', ->
       expect(tokens[1]).toEqual value: '**', scopes: ['source.asciidoc', 'markup.bold.unconstrained.asciidoc', 'support.constant.asciidoc']
       expect(tokens[2]).toEqual value: 'bold*text', scopes: ['source.asciidoc', 'markup.bold.unconstrained.asciidoc']
       expect(tokens[3]).toEqual value: '**', scopes: ['source.asciidoc', 'markup.bold.unconstrained.asciidoc', 'support.constant.asciidoc']
+
+    it 'when unconstrained **strong** is double escaped', ->
+      {tokens} = grammar.tokenizeLine '\\\\**strong text**'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqual value: '\\\\**strong text**', scopes: ['source.asciidoc']
 
     it 'when having a [role] set on unconstrained *bold* text', ->
       {tokens} = grammar.tokenizeLine '[role]**bold**'


### PR DESCRIPTION
- don't match strong phrase that is escaped (single for constrained, double for unconstrained)
- simplify match for attribute list
- don't capture unnecessary groups