### PR TITLE
Complete rewrite of snippets.

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -73,6 +73,9 @@ repository:
       {
         include: "#passthrough-block"
       }
+      {
+        include: "#open-block"
+      }
     ]
   "code-blocks":
     patterns: [
@@ -695,6 +698,14 @@ repository:
       {
         name: "markup.block.literal.asciidoc"
         begin: "(^\\.{4,}$)"
+        end: "\\1"
+      }
+    ]
+  "open-block":
+    patterns: [
+      {
+        name: "markup.raw.open.asciidoc"
+        begin: "^(-{2})$"
         end: "\\1"
       }
     ]

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -48,6 +48,8 @@ repository:
       include: '#literal-block'
     ,
       include: '#passthrough-block'
+    ,
+      include: '#open-block'
     ]
   'code-blocks':
     patterns: [

--- a/grammars/repositories/blocks/open-grammar.cson
+++ b/grammars/repositories/blocks/open-grammar.cson
@@ -1,0 +1,16 @@
+key: 'open-block'
+
+patterns: [
+
+  # Matches open block.
+  #
+  # Examples
+  #
+  # --
+  # An open block can be an anonymous container
+  # --
+  #
+  name: 'markup.raw.open.asciidoc'
+  begin: '^(-{2})$'
+  end: '\\1'
+]

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -3,7 +3,7 @@
   # Blocks
   #
   'Comment Block':
-    description: 'Comment Block'
+    description: 'Comment block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#comments'
     prefix: '//'
     body: '''
@@ -17,25 +17,25 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#delimited-blocks'
     prefix: '**'
     body: '''
-      .${1:Title}
+      .${1:title}
       ****
       ${2}
       ****
       $0
       '''
   'Example Block':
-    description: 'Example Block'
+    description: 'Example block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#example'
     prefix: '=='
     body: '''
-      .${1:Title}
+      .${1:title}
       ====
       ${2}
       ====
       $0
       '''
   'Listing Block':
-    description: 'Listing Block'
+    description: 'Listing block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
     prefix: '--'
     body: '''
@@ -44,8 +44,8 @@
       ----
       $0
       '''
-  'Code Block':
-    description: 'Code Block'
+  'Source Block':
+    description: 'Source block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
     prefix: '--s'
     body: '''
@@ -56,7 +56,7 @@
       $0
       '''
   'Literal Block':
-    description: 'Literal Block'
+    description: 'Literal block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#literal-text-and-blocks'
     prefix: ',,'
     body: '''
@@ -66,7 +66,7 @@
       $0
       '''
   'Passthrough Block':
-    description: 'Passthrough Block'
+    description: 'Passthrough block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#pass-bl'
     prefix: '++'
     body: '''
@@ -76,7 +76,7 @@
       $0
       '''
   'Quote Block':
-    description: 'Quote Block'
+    description: 'Quote block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#quote'
     prefix: '__'
     body: '''
@@ -87,7 +87,7 @@
       $0
       '''
   'Open Block':
-    description: 'Open Block'
+    description: 'Open block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#open-blocks'
     prefix: '~~'
     body: '''
@@ -96,11 +96,8 @@
       --
       $0
       '''
-
-  # Table
-  #
-  'Table':
-    description: 'Table'
+  'Table Block':
+    description: 'Table block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#tables'
     prefix: '|='
     body: '''
@@ -108,19 +105,37 @@
       |$1
       |===
       '''
+  'Block Image':
+    description: 'Block image'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
+    prefix: 'image'
+    body: '''
+      image::${1:target}[${2:alt}]
 
-  # Headings
+      $0
+      '''
+
+  # Sections
   #
-  'Heading 0':
-    description: 'Heading 0 (one-liner)'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
-    prefix: '=1'
+  'Document Title':
+    description: 'Document title (single-line syntax)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#document-title'
+    prefix: '=0'
     body: '''
       = $1
       $0
       '''
-  'Heading 1':
-    description: 'Heading 1 (one-liner)'
+  'Section 0 / Part':
+    description: 'Level 0 section / part (single-line syntax)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=1'
+    body: '''
+      = $1
+
+      $0
+      '''
+  'Section 1 / Chapter':
+    description: 'Level 1 section / chapter (single-line syntax)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=2'
     body: '''
@@ -128,8 +143,8 @@
 
       $0
       '''
-  'Heading 2':
-    description: 'Heading 2 (one-liner)'
+  'Section 2':
+    description: 'Level 2 section (single-line syntax)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=3'
     body: '''
@@ -137,8 +152,8 @@
 
       $0
       '''
-  'Heading 3':
-    description: 'Heading 3 (one-liner)'
+  'Section 3':
+    description: 'Level 3 section (single-line syntax)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=4'
     body: '''
@@ -146,8 +161,8 @@
 
       $0
       '''
-  'Heading 4':
-    description: 'Heading 4 (one-liner)'
+  'Section 4':
+    description: 'Level 4 section (single-line syntax)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=5'
     body: '''
@@ -155,85 +170,85 @@
 
       $0
       '''
+  'Section 5':
+    description: 'Level 5 section (single-line syntax)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=6'
+    body: '''
+      ====== $1
 
-  # Macro
+      $0
+      '''
+
+  # Inline Macros
   #
   'Keyboard':
-    description: 'Keyboard shortcuts'
+    description: 'Keyboard shortcut'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#keyboard-shortcuts'
-    prefix: '/kbd'
+    prefix: 'kbd'
     body: 'kbd:[$1] $0'
   'Menu selection':
-    description: 'Menu Selection'
+    description: 'Menu selection'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#menu-selections'
-    prefix: '/mn'
+    prefix: 'menu'
     body: 'menu:$1[$2] $0'
   'UI buttons':
-    description: 'UI buttons'
+    description: 'UI button'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#ui-buttons'
-    prefix: '/btn'
+    prefix: 'btn'
     body: 'btn:[$1] $0'
   'Inline Image':
-    description: 'Inline Image'
+    description: 'Inline image'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
-    prefix: '/img'
-    body: 'image:$1[$2] $0'
+    prefix: 'img'
+    body: 'image:${1:target}[${2:alt}] $0'
   'Link macro':
-    description: 'Link macro'
+    description: 'Explicit link'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
-    prefix: '/lk'
-    body: 'link:${1:url}[$2] $0'
+    prefix: 'link'
+    body: 'link:${1:url}[${2:label}] $0'
   'mailto link':
-    description: 'mailto link'
+    description: 'E-mail link'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
-    prefix: '/mt'
-    body: 'mailto:${1:email}[$2] $0'
+    prefix: 'mail'
+    body: 'mailto:${1:email}[${2:label}] $0'
   'stem':
-    description: 'stem'
+    description: 'STEM expression'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: '/stem'
-    body: 'stem:$2[$1] $0'
+    prefix: 'stem'
+    body: 'stem:[${1:expr}] $0'
   'stem asciimath':
-    description: 'stem asciimath'
+    description: 'AsciiMath STEM expression'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: '/asciimath'
-    body: 'asciimath:$2[$1] $0'
+    prefix: 'asciimath'
+    body: 'asciimath:[${1:expr}] $0'
   'stem latexmath':
-    description: 'stem latexmath'
+    description: 'LaTeX STEM expression'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: '/latexmath'
-    body: 'latexmath:$2[$1] $0'
+    prefix: 'latex'
+    body: 'latexmath:[${1:expr}] $0'
   'Footnote':
     description: 'Footnote'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
-    prefix: '/fn'
+    prefix: 'fn'
     body: 'footnote:[$1] $0'
   'Footnote reference':
     description: 'Footnote reference'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
-    prefix: '/fnr'
+    prefix: 'fnref'
     body: 'footnoteref:[$1] $0'
 
   # Others
   #
-  'Image include':
-    description: 'Image include'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
-    prefix: '/imgi'
-    body: '''
-      image::$1[$2]
-
-      $0
-      '''
   'Author':
-    description: 'Author and Email'
+    description: 'Author and email line'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#author-and-email'
-    prefix: '/aut'
+    prefix: 'author'
     body: '${1:author} <${2:email}>$0'
   'Revision information':
-    description: 'A document\'s revision information'
+    description: 'Document revision line'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#revision-number-date-and-remark'
-    prefix: '/rev'
+    prefix: 'rev'
     body: '''
       v1.0, ${3:revdate}: ${4:revremark}
       $0
@@ -241,15 +256,15 @@
   'Subscript':
     description: 'subscript'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
-    prefix: '/sub'
+    prefix: 'sub'
     body: '~$1~ $0'
   'Superscript':
     description: 'superscript'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
-    prefix: '/sup'
+    prefix: 'sup'
     body: '^$1^ $0'
   'Callout':
-    description: 'Callout numbers'
+    description: 'Callout number'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#callouts'
-    prefix: '/co'
+    prefix: 'co'
     body: '<$1> $0'

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -1,43 +1,236 @@
 '.source.asciidoc':
+
+  # Blocks
+  #
   'Comment Block':
-    'prefix': 'bl//'
-    'body': '////\n$1\n////\n$0'
-  'Example Block':
-    'prefix': 'bl=='
-    'body': '====\n$1\n====\n$0'
-  'Author Block':
-    'prefix': 'author'
-    'body': '${1:Author Name} <${2:mail@address.com}>\nv1.0, `date`, ${3:Version Comment}\n\n$0'
-  'Heading 0 (one-liner)':
-    'prefix': 'h0'
-    'body': '= $1\n\n$0'
-  'Heading 1 (one-liner)':
-    'prefix': 'h1'
-    'body': '== $1\n\n$0'
-  'Heading 2 (one-liner)':
-    'prefix': 'h2'
-    'body': '=== $1\n\n$0'
-  'Heading 3 (one-liner)':
-    'prefix': 'h3'
-    'body': '==== $1\n\n$0'
-  'Heading 4 (one-liner)':
-    'prefix': 'h4'
-    'body': '===== $1\n\n$0'
-  'Listing Block':
-    'prefix': 'bl--'
-    'body': '[source,$1]\n----\n$2\n----\n$0'
-  'Literal Block':
-    'prefix': 'bl..'
-    'body': '....\n$1\n....\n$0'
-  'Passthrough Block':
-    'prefix': 'bl++'
-    'body': '++++\n$1\n++++\n$0'
-  'Quote Block':
-    'prefix': 'bl__'
-    'body': '____\n$1\n____\n$0'
+    description: 'Comment Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#comments'
+    prefix: '//'
+    body: '''
+      ////
+      $1
+      ////
+      $0
+      '''
   'Sidebar Block':
-    'prefix': 'bl**'
-    'body': '****\n$1\n****\n$0'
+    description: 'Sidebar block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#delimited-blocks'
+    prefix: '**'
+    body: '''
+      .${1:Title}
+      ****
+      ${2}
+      ****
+      $0
+      '''
+  'Example Block':
+    description: 'Example Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#example'
+    prefix: '=='
+    body: '''
+      .${1:Title}
+      ====
+      ${2}
+      ====
+      $0
+      '''
+  'Listing Block':
+    description: 'Listing Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
+    prefix: '--'
+    body: '''
+      [source, $1]
+      ----
+      $2
+      ----
+      $0
+      '''
+  'Literal Block':
+    description: 'Literal Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#literal-text-and-blocks'
+    prefix: '/..'
+    body: '''
+      ....
+      $1
+      ....
+      $0
+      '''
+  'Passthrough Block':
+    description: 'Passthrough Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#pass-bl'
+    prefix: '++'
+    body: '''
+      ++++
+      $1
+      ++++
+      $0
+      '''
+  'Quote Block':
+    description: 'Quote Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#quote'
+    prefix: '__'
+    body: '''
+      [quote, ${1:attribution}, ${2:citetitle}]
+      ____
+      $3
+      ____
+      $0
+      '''
+
   'Table':
-    'prefix': '|='
-    'body': '.${1:Legend}\n[width="${2:100%}",cols="$3",options="$4"]\n|===\n|$5\n|==='
+    description: 'Table'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#tables'
+    prefix: '|='
+    body: '''
+      ${1:Legend}
+      [width="${2:100%}", cols="$3", options="$4"]
+      |===
+      |$5
+      |===
+      '''
+
+  # Macro
+  #
+  'Keyboard':
+    description: 'Keyboard shortcuts'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#keyboard-shortcuts'
+    prefix: 'akbd'
+    body: 'kbd:[$1] $0'
+  'Menu selection':
+    description: 'Menu Selection'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#menu-selections'
+    prefix: 'amenu'
+    body: 'menu:$1[$2] $0'
+  'UI buttons':
+    description: 'UI buttons'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#ui-buttons'
+    prefix: 'abtn'
+    body: 'btn:[$1] $0'
+  'Inline Icons':
+    description: 'Inline Icons'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#inline-icons'
+    prefix: 'aicon'
+    body: 'icon:$1[$2] $0'
+  'Link macro':
+    description: 'Link macro'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
+    prefix: 'alink'
+    body: 'link:${1:url}[$2] $0'
+  'mailto link':
+    description: 'mailto link'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
+    prefix: 'amailto'
+    body: 'mailto:${1:email}[$2] $0'
+  'stem':
+    description: 'stem'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: 'astem'
+    body: 'stem:$2[$1] $0'
+  'stem asciimath':
+    description: 'stem asciimath'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: 'aasciimath'
+    body: 'asciimath:$2[$1] $0'
+  'stem latexmath':
+    description: 'stem latexmath'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: 'alatexmath'
+    body: 'latexmath:$2[$1] $0'
+  'Footnote':
+    description: 'Footnote'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
+    prefix: 'afootnote'
+    body: 'footnote:[$1] $0'
+  'Footnote reference':
+    description: 'Footnote reference'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
+    prefix: 'afootnoteref'
+    body: 'footnoteref:[$1] $0'
+
+  # Headings
+  #
+  'Heading 0':
+    description: 'Heading 0 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=0'
+    body: '''
+       $1
+
+      $0
+      '''
+  'Heading 1':
+    description: 'Heading 1 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=1'
+    body: '''
+      = $1
+
+      $0
+      '''
+  'Heading 2':
+    description: 'Heading 2 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=2'
+    body: '''
+      == $1
+
+      $0
+      '''
+  'Heading 3':
+    description: 'Heading 3 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=3'
+    body: '''
+      === $1
+
+      $0
+      '''
+  'Heading 4':
+    description: 'Heading 4 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=4'
+    body: '''
+      ==== $1
+
+      $0
+      '''
+  'Heading 5':
+    description: 'Heading 5 (one-liner)'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
+    prefix: '=5'
+    body: '''
+      ===== $1
+
+      $0
+      '''
+
+  # Others
+  #
+  'Author':
+    description: 'Author and Email'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#author-and-email'
+    prefix: 'aauthor'
+    body: '${1:author} <${2:email}>$0'
+  'Revision information':
+    description: 'A document\'s revision information'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#revision-number-date-and-remark'
+    prefix: 'arev'
+    body: '''
+      v1.0, ${3:revdate}: ${4:revremark}
+      $0
+      '''
+  'Subscript':
+    description: 'subscript'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
+    prefix: 'asub'
+    body: '~$1~ $0'
+  'Superscript':
+    description: 'superscript'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
+    prefix: 'asub'
+    body: '^$1^ $0'
+  'Callout':
+    description: 'Callout numbers'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#callouts'
+    prefix: 'acallout'
+    body: '<$1> $0'

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -245,6 +245,14 @@
 
   # Others
   #
+  'Attribute Entry':
+    description: 'Define or update a document attribute'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#setting-attributes-on-a-document'
+    prefix: '::'
+    body: '''
+      :${1:name}:${2: value}
+      $0
+      '''
   'Author':
     description: 'Author and email line'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#author-and-email'

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -47,7 +47,7 @@
   'Source Block':
     description: 'Source block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
-    prefix: '--s'
+    prefix: '--$'
     body: '''
       [source, $1]
       ----
@@ -202,6 +202,11 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
     prefix: 'img'
     body: 'image:${1:target}[${2:alt}] $0'
+  'Inline Icon':
+    description: 'Inline icon'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#inline-icons'
+    prefix: 'icon'
+    body: 'icon:${1:target}[${2:alt}] $0'
   'Link macro':
     description: 'Explicit link'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
@@ -250,7 +255,7 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#revision-number-date-and-remark'
     prefix: 'rev'
     body: '''
-      v1.0, ${3:revdate}: ${4:revremark}
+      v${1:1.0.0}, ${2:date}
       $0
       '''
   'Subscript':

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -206,7 +206,7 @@
     description: 'Inline icon'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#inline-icons'
     prefix: 'icon'
-    body: 'icon:${1:target}[${2:alt}] $0'
+    body: 'icon:${1:name}[] $0'
   'Link macro':
     description: 'Explicit link'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'

--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -1,4 +1,4 @@
-'.source.asciidoc':
+'.source.asciidoc:not(.markup.code)':
 
   # Blocks
   #
@@ -39,6 +39,16 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
     prefix: '--'
     body: '''
+      ----
+      $1
+      ----
+      $0
+      '''
+  'Code Block':
+    description: 'Code Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#listing-blocks'
+    prefix: '--s'
+    body: '''
       [source, $1]
       ----
       $2
@@ -48,7 +58,7 @@
   'Literal Block':
     description: 'Literal Block'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#literal-text-and-blocks'
-    prefix: '/..'
+    prefix: ',,'
     body: '''
       ....
       $1
@@ -76,99 +86,41 @@
       ____
       $0
       '''
+  'Open Block':
+    description: 'Open Block'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#open-blocks'
+    prefix: '~~'
+    body: '''
+      --
+      $1
+      --
+      $0
+      '''
 
+  # Table
+  #
   'Table':
     description: 'Table'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#tables'
     prefix: '|='
     body: '''
-      ${1:Legend}
-      [width="${2:100%}", cols="$3", options="$4"]
       |===
-      |$5
+      |$1
       |===
       '''
-
-  # Macro
-  #
-  'Keyboard':
-    description: 'Keyboard shortcuts'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#keyboard-shortcuts'
-    prefix: 'akbd'
-    body: 'kbd:[$1] $0'
-  'Menu selection':
-    description: 'Menu Selection'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#menu-selections'
-    prefix: 'amenu'
-    body: 'menu:$1[$2] $0'
-  'UI buttons':
-    description: 'UI buttons'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#ui-buttons'
-    prefix: 'abtn'
-    body: 'btn:[$1] $0'
-  'Inline Icons':
-    description: 'Inline Icons'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#inline-icons'
-    prefix: 'aicon'
-    body: 'icon:$1[$2] $0'
-  'Link macro':
-    description: 'Link macro'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
-    prefix: 'alink'
-    body: 'link:${1:url}[$2] $0'
-  'mailto link':
-    description: 'mailto link'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
-    prefix: 'amailto'
-    body: 'mailto:${1:email}[$2] $0'
-  'stem':
-    description: 'stem'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: 'astem'
-    body: 'stem:$2[$1] $0'
-  'stem asciimath':
-    description: 'stem asciimath'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: 'aasciimath'
-    body: 'asciimath:$2[$1] $0'
-  'stem latexmath':
-    description: 'stem latexmath'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
-    prefix: 'alatexmath'
-    body: 'latexmath:$2[$1] $0'
-  'Footnote':
-    description: 'Footnote'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
-    prefix: 'afootnote'
-    body: 'footnote:[$1] $0'
-  'Footnote reference':
-    description: 'Footnote reference'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
-    prefix: 'afootnoteref'
-    body: 'footnoteref:[$1] $0'
 
   # Headings
   #
   'Heading 0':
     description: 'Heading 0 (one-liner)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
-    prefix: '=0'
+    prefix: '=1'
     body: '''
-       $1
-
+      = $1
       $0
       '''
   'Heading 1':
     description: 'Heading 1 (one-liner)'
-    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
-    prefix: '=1'
-    body: '''
-      = $1
-
-      $0
-      '''
-  'Heading 2':
-    description: 'Heading 2 (one-liner)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=2'
     body: '''
@@ -176,8 +128,8 @@
 
       $0
       '''
-  'Heading 3':
-    description: 'Heading 3 (one-liner)'
+  'Heading 2':
+    description: 'Heading 2 (one-liner)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=3'
     body: '''
@@ -185,8 +137,8 @@
 
       $0
       '''
-  'Heading 4':
-    description: 'Heading 4 (one-liner)'
+  'Heading 3':
+    description: 'Heading 3 (one-liner)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=4'
     body: '''
@@ -194,8 +146,8 @@
 
       $0
       '''
-  'Heading 5':
-    description: 'Heading 5 (one-liner)'
+  'Heading 4':
+    description: 'Heading 4 (one-liner)'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#sections'
     prefix: '=5'
     body: '''
@@ -204,17 +156,84 @@
       $0
       '''
 
+  # Macro
+  #
+  'Keyboard':
+    description: 'Keyboard shortcuts'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#keyboard-shortcuts'
+    prefix: '/kbd'
+    body: 'kbd:[$1] $0'
+  'Menu selection':
+    description: 'Menu Selection'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#menu-selections'
+    prefix: '/mn'
+    body: 'menu:$1[$2] $0'
+  'UI buttons':
+    description: 'UI buttons'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#ui-buttons'
+    prefix: '/btn'
+    body: 'btn:[$1] $0'
+  'Inline Image':
+    description: 'Inline Image'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
+    prefix: '/img'
+    body: 'image:$1[$2] $0'
+  'Link macro':
+    description: 'Link macro'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
+    prefix: '/lk'
+    body: 'link:${1:url}[$2] $0'
+  'mailto link':
+    description: 'mailto link'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#url'
+    prefix: '/mt'
+    body: 'mailto:${1:email}[$2] $0'
+  'stem':
+    description: 'stem'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: '/stem'
+    body: 'stem:$2[$1] $0'
+  'stem asciimath':
+    description: 'stem asciimath'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: '/asciimath'
+    body: 'asciimath:$2[$1] $0'
+  'stem latexmath':
+    description: 'stem latexmath'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#activating-stem-support'
+    prefix: '/latexmath'
+    body: 'latexmath:$2[$1] $0'
+  'Footnote':
+    description: 'Footnote'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
+    prefix: '/fn'
+    body: 'footnote:[$1] $0'
+  'Footnote reference':
+    description: 'Footnote reference'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#user-footnotes'
+    prefix: '/fnr'
+    body: 'footnoteref:[$1] $0'
+
   # Others
   #
+  'Image include':
+    description: 'Image include'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#images'
+    prefix: '/imgi'
+    body: '''
+      image::$1[$2]
+
+      $0
+      '''
   'Author':
     description: 'Author and Email'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#author-and-email'
-    prefix: 'aauthor'
+    prefix: '/aut'
     body: '${1:author} <${2:email}>$0'
   'Revision information':
     description: 'A document\'s revision information'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#revision-number-date-and-remark'
-    prefix: 'arev'
+    prefix: '/rev'
     body: '''
       v1.0, ${3:revdate}: ${4:revremark}
       $0
@@ -222,15 +241,15 @@
   'Subscript':
     description: 'subscript'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
-    prefix: 'asub'
+    prefix: '/sub'
     body: '~$1~ $0'
   'Superscript':
     description: 'superscript'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#subscript-and-superscript'
-    prefix: 'asub'
+    prefix: '/sup'
     body: '^$1^ $0'
   'Callout':
     description: 'Callout numbers'
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#callouts'
-    prefix: 'acallout'
+    prefix: '/co'
     body: '<$1> $0'

--- a/spec/blocks/open-grammar-spec.coffee
+++ b/spec/blocks/open-grammar-spec.coffee
@@ -1,0 +1,31 @@
+describe 'Should tokenizes open block when', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  # convenience function during development
+  debug = (tokens) ->
+    console.log(JSON.stringify tokens, null, ' ')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  it 'contains simple phrase', ->
+    tokens = grammar.tokenizeLines '''
+      --
+      foobar, foobar and foobar
+      --
+      '''
+    expect(tokens).toHaveLength 3
+    expect(tokens[0]).toHaveLength 1
+    expect(tokens[0][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqualJson value: 'foobar, foobar and foobar', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+    expect(tokens[2]).toHaveLength 1
+    expect(tokens[2][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']


### PR DESCRIPTION
Complete rewrite of snippets.

- add more snippets
- add `descriptionMoreURL` to link with the [AsciiDoctor documentation](http://asciidoctor.org/docs/user-manual)

Notes:
- I have prefix literal words by a `a` (like **a**sciidoc) to limit unwanted suggestions
- snippets with prefix starts with a  punctuation characters: no popup but works
- To see all the available snippets for the file type that you currently have open, you can type <kbd>alt-shift-S</kbd>.
- press <kbd>Tab</kbd> to apply snippets.

Fix #23


