### PR TITLE
Allow additional attributes to be defined on source block

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -785,6 +785,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.c.asciidoc"
@@ -818,6 +824,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.clojure.asciidoc"
@@ -851,6 +863,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.coffee.asciidoc"
@@ -884,6 +902,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.cpp.asciidoc"
@@ -917,6 +941,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.css.asciidoc"
@@ -950,6 +980,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.cs.asciidoc"
@@ -983,6 +1019,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.diff.asciidoc"
@@ -1016,6 +1058,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.dockerfile.asciidoc"
@@ -1049,6 +1097,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.elixir.asciidoc"
@@ -1082,6 +1136,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.elm.asciidoc"
@@ -1115,6 +1175,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.erlang.asciidoc"
@@ -1148,6 +1214,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.go.asciidoc"
@@ -1181,6 +1253,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.groovy.asciidoc"
@@ -1214,6 +1292,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.haskell.asciidoc"
@@ -1247,6 +1331,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.html.basic.asciidoc"
@@ -1280,6 +1370,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.java.asciidoc"
@@ -1313,6 +1409,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.js.asciidoc"
@@ -1346,6 +1448,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.json.asciidoc"
@@ -1379,6 +1487,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.js.jsx.asciidoc"
@@ -1412,6 +1526,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.julia.asciidoc"
@@ -1445,6 +1565,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.css.less.asciidoc"
@@ -1478,6 +1604,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.makefile.asciidoc"
@@ -1511,6 +1643,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.gfm.asciidoc"
@@ -1544,6 +1682,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.html.mustache.asciidoc"
@@ -1577,6 +1721,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.objc.asciidoc"
@@ -1610,6 +1760,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.ocaml.asciidoc"
@@ -1643,6 +1799,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.perl.asciidoc"
@@ -1676,6 +1838,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.perl6.asciidoc"
@@ -1709,6 +1877,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.html.php.asciidoc"
@@ -1742,6 +1916,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.asciidoc.properties.asciidoc"
@@ -1775,6 +1955,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.python.asciidoc"
@@ -1808,6 +1994,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.r.asciidoc"
@@ -1841,6 +2033,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.ruby.asciidoc"
@@ -1874,6 +2072,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.rust.asciidoc"
@@ -1907,6 +2111,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.sass.asciidoc"
@@ -1940,6 +2150,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.scala.asciidoc"
@@ -1973,6 +2189,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.css.scss.asciidoc"
@@ -2006,6 +2228,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.shell.asciidoc"
@@ -2039,6 +2267,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.sql.asciidoc"
@@ -2072,6 +2306,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.swift.asciidoc"
@@ -2105,6 +2345,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.toml.asciidoc"
@@ -2138,6 +2384,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.ts.asciidoc"
@@ -2171,6 +2423,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.xml.asciidoc"
@@ -2204,6 +2462,12 @@ repository:
             name: "constant.asciidoc"
           "2":
             name: "string.asciidoc"
+          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
         patterns: [
           {
             name: "markup.code.yaml.asciidoc"
@@ -2256,6 +2520,22 @@ repository:
                 name: "support.asciidoc"
           }
         ]
+      }
+      {
+        name: "markup.raw.asciidoc"
+        begin: "^(-{4,})\\s*$"
+        beginCaptures:
+          "0":
+            name: "support.asciidoc"
+        patterns: [
+          {
+            include: "#block-callout"
+          }
+        ]
+        end: "^\\1*$"
+        endCaptures:
+          "0":
+            name: "support.asciidoc"
       }
     ]
   "source-markdown":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -777,19 +777,19 @@ repository:
   "source-asciidoctor":
     patterns: [
       {
-        begin: "^\\[source,\\s*(?i:(c))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(c))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.c.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.c"
@@ -801,24 +801,28 @@ repository:
                 include: "source.c"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(clojure))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(clojure))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.clojure.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.clojure"
@@ -830,24 +834,28 @@ repository:
                 include: "source.clojure"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(coffee-?(script)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(coffee-?(script)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.coffee.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.coffee"
@@ -859,24 +867,28 @@ repository:
                 include: "source.coffee"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(c(pp|\\+\\+)))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.cpp.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.cpp"
@@ -888,24 +900,28 @@ repository:
                 include: "source.cpp"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(css))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(css))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.css.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.css"
@@ -917,24 +933,28 @@ repository:
                 include: "source.css"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(cs(harp)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(cs(harp)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.cs.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.cs"
@@ -946,24 +966,28 @@ repository:
                 include: "source.cs"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(diff|patch|rej))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(diff|patch|rej))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.diff.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.diff"
@@ -975,24 +999,28 @@ repository:
                 include: "source.diff"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(docker(file)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(docker(file)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.dockerfile.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.dockerfile"
@@ -1004,24 +1032,28 @@ repository:
                 include: "source.dockerfile"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(elixir))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(elixir))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.elixir.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.elixir"
@@ -1033,24 +1065,28 @@ repository:
                 include: "source.elixir"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(elm))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(elm))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.elm.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.elm"
@@ -1062,24 +1098,28 @@ repository:
                 include: "source.elm"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(erlang))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(erlang))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.erlang.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.erlang"
@@ -1091,24 +1131,28 @@ repository:
                 include: "source.erlang"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(go(lang)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(go(lang)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.go.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.go"
@@ -1120,24 +1164,28 @@ repository:
                 include: "source.go"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(groovy))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(groovy))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.groovy.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.groovy"
@@ -1149,24 +1197,28 @@ repository:
                 include: "source.groovy"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(haskell))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(haskell))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.haskell.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.haskell"
@@ -1178,24 +1230,28 @@ repository:
                 include: "source.haskell"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(html))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(html))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.html.basic.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "text.embedded.html.basic"
@@ -1207,24 +1263,28 @@ repository:
                 include: "text.html.basic"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(java))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(java))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.java.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.java"
@@ -1236,24 +1296,28 @@ repository:
                 include: "source.java"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(javascript|js))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(javascript|js))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.js.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.js"
@@ -1265,24 +1329,28 @@ repository:
                 include: "source.js"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(json))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(json))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.json.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.json"
@@ -1294,24 +1362,28 @@ repository:
                 include: "source.json"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(jsx))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(jsx))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.js.jsx.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.js.jsx"
@@ -1323,24 +1395,28 @@ repository:
                 include: "source.js.jsx"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(julia))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(julia))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.julia.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.julia"
@@ -1352,24 +1428,28 @@ repository:
                 include: "source.julia"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(less))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(less))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.css.less.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.css.less"
@@ -1381,24 +1461,28 @@ repository:
                 include: "source.css.less"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(make(file)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(make(file)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.makefile.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.makefile"
@@ -1410,24 +1494,28 @@ repository:
                 include: "source.makefile"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(markdown|mdown|md))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(markdown|mdown|md))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.gfm.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.gfm"
@@ -1439,24 +1527,28 @@ repository:
                 include: "source.gfm"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(mustache))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(mustache))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.html.mustache.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "text.embedded.html.mustache"
@@ -1468,24 +1560,28 @@ repository:
                 include: "text.html.mustache"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(objc|objective-c))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(objc|objective-c))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.objc.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.objc"
@@ -1497,24 +1593,28 @@ repository:
                 include: "source.objc"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(ocaml))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(ocaml))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.ocaml.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.ocaml"
@@ -1526,24 +1626,28 @@ repository:
                 include: "source.ocaml"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(perl))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(perl))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.perl.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.perl"
@@ -1555,24 +1659,28 @@ repository:
                 include: "source.perl"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(perl6))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(perl6))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.perl6.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.perl6"
@@ -1584,24 +1692,28 @@ repository:
                 include: "source.perl6"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(php))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(php))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.html.php.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "text.embedded.html.php"
@@ -1613,24 +1725,28 @@ repository:
                 include: "text.html.php"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(properties))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(properties))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.asciidoc.properties.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.asciidoc.properties"
@@ -1642,24 +1758,28 @@ repository:
                 include: "source.asciidoc.properties"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(py(thon)?))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(py(thon)?))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.python.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.python"
@@ -1671,24 +1791,28 @@ repository:
                 include: "source.python"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(r))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(r))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.r.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.r"
@@ -1700,24 +1824,28 @@ repository:
                 include: "source.r"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(ruby|rb))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(ruby|rb))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.ruby.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.ruby"
@@ -1729,24 +1857,28 @@ repository:
                 include: "source.ruby"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(rust|rs))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(rust|rs))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.rust.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.rust"
@@ -1758,24 +1890,28 @@ repository:
                 include: "source.rust"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(sass))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(sass))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.sass.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.sass"
@@ -1787,24 +1923,28 @@ repository:
                 include: "source.sass"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(scala))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(scala))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.scala.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.scala"
@@ -1816,24 +1956,28 @@ repository:
                 include: "source.scala"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(scss))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(scss))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.css.scss.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.css.scss"
@@ -1845,24 +1989,28 @@ repository:
                 include: "source.css.scss"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(sh|bash|shell))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(sh|bash|shell))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.shell.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.shell"
@@ -1874,24 +2022,28 @@ repository:
                 include: "source.shell"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(sql))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(sql))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.sql.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.sql"
@@ -1903,24 +2055,28 @@ repository:
                 include: "source.sql"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(swift))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(swift))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.swift.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.swift"
@@ -1932,24 +2088,28 @@ repository:
                 include: "source.swift"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(toml))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(toml))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.toml.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.toml"
@@ -1961,24 +2121,28 @@ repository:
                 include: "source.toml"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(typescript|ts))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(typescript|ts))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.ts.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.ts"
@@ -1990,24 +2154,28 @@ repository:
                 include: "source.ts"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(xml))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(xml))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.xml.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "text.embedded.xml"
@@ -2019,24 +2187,28 @@ repository:
                 include: "text.xml"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\[source,\\s*(?i:(ya?ml))\\]$"
+        begin: "^\\[(source),\\p{Blank}*(?i:(ya?ml))(?:,([^]]*))?\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         patterns: [
           {
             name: "markup.code.yaml.asciidoc"
             begin: "^(-{4,})\\s*$"
             beginCaptures:
-              "0":
-                name: "support.asciidoc"
-            end: "^\\1*$"
-            endCaptures:
               "0":
                 name: "support.asciidoc"
             contentName: "source.embedded.yaml"
@@ -2048,15 +2220,23 @@ repository:
                 include: "source.yaml"
               }
             ]
+            end: "^\\1*$"
+            endCaptures:
+              "0":
+                name: "support.asciidoc"
           }
         ]
         end: "(?<=----)[\\r\\n]+$"
       }
       {
-        begin: "^\\s*\\[source(,[^\\],]*)?\\]$"
+        begin: "^\\[(source)(?:,([^,\\]]*)){0,2}\\]$"
         beginCaptures:
           "0":
             name: "support.asciidoc"
+          "1":
+            name: "constant.asciidoc"
+          "2":
+            name: "string.asciidoc"
         end: "(?<=----)[\\r\\n]+$"
         patterns: [
           {

--- a/lib/code-block-generator.coffee
+++ b/lib/code-block-generator.coffee
@@ -9,6 +9,10 @@ module.exports =
         0: name: 'support.asciidoc'
         1: name: 'constant.asciidoc'
         2: name: 'string.asciidoc'
+        3:
+          patterns: [
+            include: '#attribute-reference'
+          ]
       patterns: [
         name: "markup.code.#{lang.code}.asciidoc"
         begin: '^(-{4,})\\s*$'
@@ -44,6 +48,16 @@ module.exports =
         endCaptures:
           0: name: 'support.asciidoc'
       ]
+    # add listing block
+    codeBlocks.push
+      name: 'markup.raw.asciidoc'
+      begin: '^(-{4,})\\s*$'
+      beginCaptures:
+        0: name: 'support.asciidoc'
+      patterns: [include: '#block-callout']
+      end: '^\\1*$'
+      endCaptures:
+        0: name: 'support.asciidoc'
 
     if debug
       console.log CSON.stringify codeBlocks

--- a/lib/code-block-generator.coffee
+++ b/lib/code-block-generator.coffee
@@ -4,16 +4,15 @@ module.exports =
   makeAsciidocBlocks: (languages, debug = false) ->
     # add languages blocks
     codeBlocks = languages.map (lang) ->
-      begin: "^\\[source,\\s*(?i:(#{lang.pattern}))\\]$"
+      begin: "^\\[(source),\\p{Blank}*(?i:(#{lang.pattern}))(?:,([^\]]*))?\\]$"
       beginCaptures:
         0: name: 'support.asciidoc'
+        1: name: 'constant.asciidoc'
+        2: name: 'string.asciidoc'
       patterns: [
         name: "markup.code.#{lang.code}.asciidoc"
         begin: '^(-{4,})\\s*$'
         beginCaptures:
-          0: name: 'support.asciidoc'
-        end: '^\\1*$'
-        endCaptures:
           0: name: 'support.asciidoc'
         contentName: "#{lang.type}.embedded.#{lang.code}"
         patterns: [
@@ -21,14 +20,19 @@ module.exports =
         ,
           include: "#{lang.type}.#{lang.code}"
         ]
+        end: '^\\1*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
       ]
       end: '(?<=----)[\\r\\n]+$'
 
     # add generic block
     codeBlocks.push
-      begin: '^\\s*\\[source(,[^\\],]*)?\\]$'
+      begin: '^\\[(source)(?:,([^,\\]]*)){0,2}\\]$'
       beginCaptures:
         0: name: 'support.asciidoc'
+        1: name: 'constant.asciidoc'
+        2: name: 'string.asciidoc'
       end: '(?<=----)[\\r\\n]+$'
       patterns: [
         name: 'markup.raw.asciidoc'

--- a/spec/blocks/code-block-grammar-spec.coffee
+++ b/spec/blocks/code-block-grammar-spec.coffee
@@ -62,3 +62,29 @@ describe 'Should tokenizes code block when', ->
     expect(tokens[6][6]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
     expect(tokens[6][7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
     expect(tokens[6][8]).toEqualJson value: '_rules_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.italic.asciidoc']
+
+  it 'contains substitutions in additional attributes', ->
+    tokens = grammar.tokenizeLines '''
+      [source,java,subs="{markup-in-source}"]
+      ----
+      System.out.println("Hello *bold* text").
+      ----
+      '''
+    expect(tokens).toHaveLength 4 # Number of lines
+    expect(tokens[0]).toHaveLength 9
+    expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][1]).toEqualJson value: 'source', scopes: ['source.asciidoc', 'support.asciidoc', 'constant.asciidoc']
+    expect(tokens[0][2]).toEqualJson value: ',', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][3]).toEqualJson value: 'java', scopes: ['source.asciidoc', 'support.asciidoc', 'string.asciidoc']
+    expect(tokens[0][4]).toEqualJson value: ',', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][5]).toEqualJson value: 'subs="', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][6]).toEqualJson value: '{markup-in-source}', scopes: ['source.asciidoc', 'support.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+    expect(tokens[0][7]).toEqualJson value: '"', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][8]).toEqualJson value: ']', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'support.asciidoc']
+    expect(tokens[2]).toHaveLength 1
+    expect(tokens[2][0]).toEqualJson value: 'System.out.println("Hello *bold* text").', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'source.embedded.java']
+    expect(tokens[3]).toHaveLength 2
+    expect(tokens[3][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'support.asciidoc']
+    expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc']

--- a/spec/blocks/code-block-grammar-spec.coffee
+++ b/spec/blocks/code-block-grammar-spec.coffee
@@ -27,34 +27,38 @@ describe 'Should tokenizes code block when', ->
                                     <2> *CoffeeLint* _rules_
                                     '''
     expect(tokens).toHaveLength 7 # Number of lines
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqual value: '[source,shell]', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0]).toHaveLength 5
+    expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][1]).toEqualJson value: 'source', scopes: ['source.asciidoc', 'support.asciidoc', 'constant.asciidoc']
+    expect(tokens[0][2]).toEqualJson value: ',', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][3]).toEqualJson value: 'shell', scopes: ['source.asciidoc', 'support.asciidoc', 'string.asciidoc']
+    expect(tokens[0][4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'support.asciidoc']
     expect(tokens[1]).toHaveLength 1
-    expect(tokens[1][0]).toEqual value: '----', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'support.asciidoc']
+    expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'support.asciidoc']
     expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqual value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
+    expect(tokens[2][0]).toEqualJson value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
     expect(tokens[3]).toHaveLength 1
-    expect(tokens[3][0]).toEqual value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
+    expect(tokens[3][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
     expect(tokens[4]).toHaveLength 2
-    expect(tokens[4][0]).toEqual value: '----', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'support.asciidoc']
-    expect(tokens[4][1]).toEqual value: '', scopes: ['source.asciidoc']
+    expect(tokens[4][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'support.asciidoc']
+    expect(tokens[4][1]).toEqualJson value: '', scopes: ['source.asciidoc']
     expect(tokens[5]).toHaveLength 9
-    expect(tokens[5][0]).toEqual value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[5][1]).toEqual value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[5][2]).toEqual value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[5][3]).toEqual value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[5][4]).toEqual value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[5][5]).toEqual value: 'Grammars', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc']
-    expect(tokens[5][6]).toEqual value: '*', scopes: [ 'source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[5][7]).toEqual value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[5][8]).toEqual value: '_definition_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.italic.asciidoc']
+    expect(tokens[5][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[5][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+    expect(tokens[5][4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[5][5]).toEqualJson value: 'Grammars', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[5][6]).toEqualJson value: '*', scopes: [ 'source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[5][7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+    expect(tokens[5][8]).toEqualJson value: '_definition_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.italic.asciidoc']
     expect(tokens[5]).toHaveLength 9
-    expect(tokens[6][0]).toEqual value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[6][1]).toEqual value: '2', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[6][2]).toEqual value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[6][3]).toEqual value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[6][4]).toEqual value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[6][5]).toEqual value: 'CoffeeLint', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc']
-    expect(tokens[6][6]).toEqual value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[6][7]).toEqual value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[6][8]).toEqual value: '_rules_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.italic.asciidoc']
+    expect(tokens[6][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[6][1]).toEqualJson value: '2', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[6][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[6][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+    expect(tokens[6][4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[6][5]).toEqualJson value: 'CoffeeLint', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc']
+    expect(tokens[6][6]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.bold.constrained.asciidoc', 'support.constant.asciidoc']
+    expect(tokens[6][7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+    expect(tokens[6][8]).toEqualJson value: '_rules_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.italic.asciidoc']

--- a/spec/code-block-generator-spec.coffee
+++ b/spec/code-block-generator-spec.coffee
@@ -7,7 +7,7 @@ describe 'Code block generator', ->
     it 'should generate default code block', ->
       languages = []
       codeBlocks = generator.makeAsciidocBlocks(languages)
-      expect(codeBlocks).toHaveLength 1 # Number of blocks
+      expect(codeBlocks).toHaveLength 2 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
         begin: '^\\[(source)(?:,([^,\\]]*)){0,2}\\]$'
         beginCaptures:
@@ -26,18 +26,36 @@ describe 'Code block generator', ->
         ]
         end: '(?<=----)[\\r\\n]+$'
 
+    it 'should generate listing block', ->
+      languages = []
+      codeBlocks = generator.makeAsciidocBlocks(languages)
+      expect(codeBlocks).toHaveLength 2 # Number of blocks
+      expect(codeBlocks[1]).toEqualJson
+        name: 'markup.raw.asciidoc'
+        begin: '^(-{4,})\\s*$'
+        beginCaptures:
+          0: name: 'support.asciidoc'
+        patterns: [include: '#block-callout']
+        end: '^\\1*$'
+        endCaptures:
+          0: name: 'support.asciidoc'
+
     it 'should generate Javascript code block', ->
       languages = [
         pattern: 'javascript|js', type: 'source', code: 'js'
       ]
       codeBlocks = generator.makeAsciidocBlocks(languages)
-      expect(codeBlocks).toHaveLength 2 # Number of blocks
+      expect(codeBlocks).toHaveLength 3 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
         begin: '^\\[(source),\\p{Blank}*(?i:(javascript|js))(?:,([^\]]*))?\\]$'
         beginCaptures:
           0: name: 'support.asciidoc'
           1: name: 'constant.asciidoc'
           2: name: 'string.asciidoc'
+          3:
+            patterns: [
+              include: '#attribute-reference'
+            ]
         patterns: [
           name: 'markup.code.js.asciidoc'
           begin: '^(-{4,})\\s*$'
@@ -60,13 +78,17 @@ describe 'Code block generator', ->
         pattern: 'c(pp|\\+\\+)', type: 'source', code: 'cpp'
       ]
       codeBlocks = generator.makeAsciidocBlocks(languages)
-      expect(codeBlocks).toHaveLength 2 # Number of blocks
+      expect(codeBlocks).toHaveLength 3 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
         begin: '^\\[(source),\\p{Blank}*(?i:(c(pp|\\+\\+)))(?:,([^\]]*))?\\]$'
         beginCaptures:
           0: name: 'support.asciidoc'
           1: name: 'constant.asciidoc'
           2: name: 'string.asciidoc'
+          3:
+            patterns: [
+              include: '#attribute-reference'
+            ]
         end: '(?<=----)[\\r\\n]+$'
         patterns: [
           name: 'markup.code.cpp.asciidoc'

--- a/spec/code-block-generator-spec.coffee
+++ b/spec/code-block-generator-spec.coffee
@@ -9,10 +9,11 @@ describe 'Code block generator', ->
       codeBlocks = generator.makeAsciidocBlocks(languages)
       expect(codeBlocks).toHaveLength 1 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
-        begin: '^\\s*\\[source(,[^\\],]*)?\\]$'
+        begin: '^\\[(source)(?:,([^,\\]]*)){0,2}\\]$'
         beginCaptures:
           0: name: 'support.asciidoc'
-        end: '(?<=----)[\\r\\n]+$'
+          1: name: 'constant.asciidoc'
+          2: name: 'string.asciidoc'
         patterns: [
           name: 'markup.raw.asciidoc'
           begin: '^(-{4,})\\s*$'
@@ -23,6 +24,7 @@ describe 'Code block generator', ->
           endCaptures:
             0: name: 'support.asciidoc'
         ]
+        end: '(?<=----)[\\r\\n]+$'
 
     it 'should generate Javascript code block', ->
       languages = [
@@ -31,16 +33,15 @@ describe 'Code block generator', ->
       codeBlocks = generator.makeAsciidocBlocks(languages)
       expect(codeBlocks).toHaveLength 2 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
-        begin: '^\\[source,\\s*(?i:(javascript|js))\\]$'
+        begin: '^\\[(source),\\p{Blank}*(?i:(javascript|js))(?:,([^\]]*))?\\]$'
         beginCaptures:
           0: name: 'support.asciidoc'
+          1: name: 'constant.asciidoc'
+          2: name: 'string.asciidoc'
         patterns: [
           name: 'markup.code.js.asciidoc'
           begin: '^(-{4,})\\s*$'
           beginCaptures:
-            0: name: 'support.asciidoc'
-          end: '^\\1*$'
-          endCaptures:
             0: name: 'support.asciidoc'
           contentName: 'source.embedded.js'
           patterns: [
@@ -48,6 +49,9 @@ describe 'Code block generator', ->
           ,
             include: 'source.js'
           ]
+          end: '^\\1*$'
+          endCaptures:
+            0: name: 'support.asciidoc'
         ]
         end: '(?<=----)[\\r\\n]+$'
 
@@ -58,17 +62,16 @@ describe 'Code block generator', ->
       codeBlocks = generator.makeAsciidocBlocks(languages)
       expect(codeBlocks).toHaveLength 2 # Number of blocks
       expect(codeBlocks[0]).toEqualJson
-        begin: '^\\[source,\\s*(?i:(c(pp|\\+\\+)))\\]$'
+        begin: '^\\[(source),\\p{Blank}*(?i:(c(pp|\\+\\+)))(?:,([^\]]*))?\\]$'
         beginCaptures:
           0: name: 'support.asciidoc'
+          1: name: 'constant.asciidoc'
+          2: name: 'string.asciidoc'
         end: '(?<=----)[\\r\\n]+$'
         patterns: [
           name: 'markup.code.cpp.asciidoc'
           begin: '^(-{4,})\\s*$'
           beginCaptures:
-            0: name: 'support.asciidoc'
-          end: '^\\1*$'
-          endCaptures:
             0: name: 'support.asciidoc'
           contentName: 'source.embedded.cpp'
           patterns: [
@@ -76,6 +79,9 @@ describe 'Code block generator', ->
           ,
             include: 'source.cpp'
           ]
+          end: '^\\1*$'
+          endCaptures:
+            0: name: 'support.asciidoc'
         ]
 
   describe 'with Markdown syntax', ->

--- a/spec/partials/block-callout-grammar-spec.coffee
+++ b/spec/partials/block-callout-grammar-spec.coffee
@@ -27,29 +27,33 @@ describe 'Should tokenizes callout in code block when', ->
                                       ----
                                       '''
     expect(tokens).toHaveLength 8
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqual value: '[source, js]', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0]).toHaveLength 5
+    expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][1]).toEqualJson value: 'source', scopes: ['source.asciidoc', 'support.asciidoc', 'constant.asciidoc']
+    expect(tokens[0][2]).toEqualJson value: ', ', scopes: ['source.asciidoc', 'support.asciidoc']
+    expect(tokens[0][3]).toEqualJson value: 'js', scopes: ['source.asciidoc', 'support.asciidoc', 'string.asciidoc']
+    expect(tokens[0][4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'support.asciidoc']
     expect(tokens[1]).toHaveLength 1
-    expect(tokens[1][0]).toEqual value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'support.asciidoc']
+    expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'support.asciidoc']
     expect(tokens[2]).toHaveLength 4
-    expect(tokens[2][0]).toEqual value: 'var http = require(\'http\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[2][1]).toEqual value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[2][2]).toEqual value: '1', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[2][3]).toEqual value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[2][0]).toEqualJson value: 'var http = require(\'http\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[2][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[2][2]).toEqualJson value: '1', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[2][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[3]).toHaveLength 4
-    expect(tokens[3][0]).toEqual value: 'http.createServer(function (req, res) { ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[3][1]).toEqual value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[3][2]).toEqual value: '2', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[3][3]).toEqual value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[3][0]).toEqualJson value: 'http.createServer(function (req, res) { ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[3][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[3][2]).toEqualJson value: '2', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[3][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[4]).toHaveLength 1
-    expect(tokens[4][0]).toEqual value: '  res.end(\'Hello World', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[4][0]).toEqualJson value: '  res.end(\'Hello World', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
     expect(tokens[5]).toHaveLength 4
-    expect(tokens[5][0]).toEqual value: '\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[5][1]).toEqual value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[5][2]).toEqual value: '3', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[5][3]).toEqual value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5][0]).toEqualJson value: '\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[5][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5][2]).toEqualJson value: '3', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[5][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[6]).toHaveLength 1
-    expect(tokens[6][0]).toEqual value: '}).listen(1337, \'127.0.0.1\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[6][0]).toEqualJson value: '}).listen(1337, \'127.0.0.1\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
     expect(tokens[7]).toHaveLength 2
-    expect(tokens[7][0]).toEqual value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'support.asciidoc']
-    expect(tokens[7][1]).toEqual value: '', scopes: ['source.asciidoc']
+    expect(tokens[7][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'support.asciidoc']
+    expect(tokens[7][1]).toEqualJson value: '', scopes: ['source.asciidoc']


### PR DESCRIPTION

![capture du 2016-05-08 23-02-55](https://cloud.githubusercontent.com/assets/5674651/15100412/1b657d0c-1571-11e6-9cf4-2a1eb8dcfaa6.png)

```adoc
[source,ruby,subs=attributes+]
----
source 'https://rubygems.org'
gem 'asciidoctor', '{latest-release}'
----
```

Fix #93