### PR TITLE
order unconstrained monospace before constrained

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -536,12 +536,12 @@ repository:
   monospaced:
     patterns: [
       {
-        name: "markup.raw.constrained.monospaced.asciidoc"
-        match: "(?<![\\\\;:\\p{Word}\"'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}\"'`])"
-      }
-      {
         name: "markup.raw.unconstrained.monospaced.asciidoc"
         match: "(?<!\\\\)(?:\\[.+?\\])?``(?:.+?)``"
+      }
+      {
+        name: "markup.raw.constrained.monospaced.asciidoc"
+        match: "(?<![\\\\;:\\p{Word}\"'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}\"'`])"
       }
     ]
   "passthrough-macro":

--- a/grammars/repositories/inlines/monospaced-grammar.cson
+++ b/grammars/repositories/inlines/monospaced-grammar.cson
@@ -1,16 +1,6 @@
 key: 'monospaced'
 
 patterns: [
-
-  # Matches constrained monospaced inlines
-  #
-  # Examples
-  #
-  #   `Text in backticks` renders exactly as entered, in `monospaced`.
-  #
-  name: 'markup.raw.constrained.monospaced.asciidoc'
-  match: '(?<![\\\\;:\\p{Word}"\'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}"\'`])'
-,
   # Matches unconstrained monospaced inlines
   #
   # Examples
@@ -19,4 +9,13 @@ patterns: [
   #
   name: 'markup.raw.unconstrained.monospaced.asciidoc'
   match: '(?<!\\\\)(?:\\[.+?\\])?``(?:.+?)``'
+,
+  # Matches constrained monospaced inlines
+  #
+  # Examples
+  #
+  #   `Text in backticks` renders exactly as entered, in `monospaced`.
+  #
+  name: 'markup.raw.constrained.monospaced.asciidoc'
+  match: '(?<![\\\\;:\\p{Word}"\'`])(?:\\[.+?\\])?`(?:\\S|\\S.*?\\S)`(?![\\p{Word}"\'`])'
 ]


### PR DESCRIPTION
This is primarily an internal change that makes the grammar more accurate.