### PR TITLE
feat: use Shadow DOM

### DIFF
--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -2,7 +2,7 @@
 
 @syntax-text-color-unobtrusive: fadeout(@syntax-text-color, 50%);
 
-atom-text-editor, :host {
+atom-text-editor::shadow, :host {
   .asciidoc {
 
     .markup{


### PR DESCRIPTION
> the shadow DOM is now enabled by default to prevent style pollution in Atom’s text editor component.

http://blog.atom.io/2015/01/05/enable-shadow-dom.html