### PR TITLE
add template for man page to snippets

### DIFF
--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -291,3 +291,50 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#checklist'
     prefix: '-x'
     body: '- [x] $0'
+
+  # Templates
+  #
+  'Man Page':
+    description: 'Man page template'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#man-pages'
+    # See also http://docopt.org/ for how to describe commmand line options.
+    prefix: 'man'
+    body: '''
+      = {manname}(1)
+      ${1:Author Name}
+      v${2:1.0.0}
+      :doctype: manpage
+      :manname: ${3:command}
+      :manmanual: User Commands
+      :mansource: {revnumber}
+
+      == NAME
+
+      {manname} - ${4:description}
+
+      == SYNOPSIS
+
+      *{manname}* ['OPTION']... 'FILE'...
+
+      == OPTIONS
+
+      *-${5:short-option}, --${6:long-option}*::
+        ${7:Description of option.}
+
+      $0
+
+      == EXIT STATUS
+
+      *0*::
+        Success.
+
+      *1*::
+        Failure.
+
+      == COPYRIGHT
+
+      Copyright \\\\(C) {author}.
+
+      This is free software.
+      See the source for copying conditions.
+      '''


### PR DESCRIPTION
Man pages require a special document structure. This snippet gets you started.