### PR TITLE
feat: Preventing substitutions

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -381,7 +381,7 @@ repository:
   "anchor-macro":
     patterns: [
       {
-        match: "\\\\?(?:(\\[{2})([\\p{Alpha}:_][\\p{Word}:.-]*)(?:,\\p{Blank}*(\\S.*?))?(\\]{2}))"
+        match: "(?<!\\\\)(?:(\\[{2})([\\p{Alpha}:_][\\p{Word}:.-]*)(?:,\\p{Blank}*(\\S.*?))?(\\]{2}))"
         captures:
           "1":
             name: "support.constant.asciidoc"
@@ -391,7 +391,7 @@ repository:
             name: "support.constant.asciidoc"
       }
       {
-        match: "\\\\?(anchor:)(\\S+)(\\[)(.*?[^\\\\])?(\\])"
+        match: "(?<!\\\\)(anchor:)(\\S+)(\\[)(.*?[^\\\\])?(\\])"
         captures:
           "1":
             name: "support.constant.asciidoc"
@@ -502,7 +502,7 @@ repository:
     patterns: [
       {
         name: "markup.macro.inline.image.general.asciidoc"
-        match: "\\\\?(?:image|icon):([^:\\[][^\\[]*)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])"
+        match: "(?<!\\\\)(?:image|icon):([^:\\[][^\\[]*)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])"
         captures:
           "1":
             name: "support.constant.asciidoc"
@@ -516,7 +516,7 @@ repository:
     patterns: [
       {
         name: "markup.macro.inline.kbd.general.asciidoc"
-        match: "\\\\?(?:kbd|btn):(\\[)((?:\\\\\\]|[^\\]])+?)(\\])"
+        match: "(?<!\\\\)(?:kbd|btn):(\\[)((?:\\\\\\]|[^\\]])+?)(\\])"
         captures:
           "2":
             name: "support.constant.asciidoc"
@@ -533,7 +533,7 @@ repository:
       }
       {
         name: "markup.link.inline.asciidoc"
-        match: "\\\\?(?:link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
+        match: "(?<!\\\\)(?:link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
         captures:
           "1":
             name: "support.constant.link.inline.asciidoc"
@@ -547,7 +547,7 @@ repository:
     patterns: [
       {
         name: "markup.link.menu.inline.asciidoc"
-        match: "\\\\?menu:(\\p{Word}|\\p{Word}.*?\\S)\\[\\p{Blank}*(.+?)?\\]"
+        match: "(?<!\\\\)menu:(\\p{Word}|\\p{Word}.*?\\S)\\[\\p{Blank}*(.+?)?\\]"
         captures:
           "1":
             name: "support.constant.menu.inline.asciidoc"
@@ -625,7 +625,7 @@ repository:
     patterns: [
       {
         name: "markup.macro.inline.stem.general.asciidoc"
-        match: "\\\\?(stem|(?:latex|ascii)math):([a-z,]*)(\\[)(.*?[^\\\\])(\\])"
+        match: "(?<!\\\\)(stem|(?:latex|ascii)math):([a-z,]*)(\\[)(.*?[^\\\\])(\\])"
         captures:
           "2":
             name: "support.constant.asciidoc"

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -409,7 +409,7 @@ repository:
     patterns: [
       {
         name: "markup.substitution.attribute-reference.asciidoc"
-        match: "(\\\\)?(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})"
+        match: "(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})"
       }
     ]
   "bibliography-anchor":
@@ -430,7 +430,7 @@ repository:
     patterns: [
       {
         name: "markup.htmlentity.asciidoc"
-        match: "(&)(\\S+?)(;)"
+        match: "(?<!\\\\)(&)(\\S+?)(;)"
         captures:
           "1":
             name: "support.constant.asciidoc"

--- a/grammars/repositories/inlines/anchor-macro-grammar.cson
+++ b/grammars/repositories/inlines/anchor-macro-grammar.cson
@@ -9,7 +9,7 @@ patterns: [
   #   [[idname]]
   #   [[idname,Reference Text]]
   #
-  match: '\\\\?(?:(\\[{2})([\\p{Alpha}:_][\\p{Word}:.-]*)(?:,\\p{Blank}*(\\S.*?))?(\\]{2}))'
+  match: '(?<!\\\\)(?:(\\[{2})([\\p{Alpha}:_][\\p{Word}:.-]*)(?:,\\p{Blank}*(\\S.*?))?(\\]{2}))'
   captures:
     1: name: 'support.constant.asciidoc'
     2: name: 'markup.blockid.asciidoc'
@@ -22,7 +22,7 @@ patterns: [
   #   anchor:idname[]
   #   anchor:idname[Reference Text]
   #
-  match: '\\\\?(anchor:)(\\S+)(\\[)(.*?[^\\\\])?(\\])'
+  match: '(?<!\\\\)(anchor:)(\\S+)(\\[)(.*?[^\\\\])?(\\])'
   captures:
     1: name: 'support.constant.asciidoc'
     2: name: 'markup.blockid.asciidoc'

--- a/grammars/repositories/inlines/attribute-reference-grammar.cson
+++ b/grammars/repositories/inlines/attribute-reference-grammar.cson
@@ -12,6 +12,6 @@ patterns: [
   #   {set:name!}
   #
   name: 'markup.substitution.attribute-reference.asciidoc'
-  match: '(\\\\)?(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})'
+  match: '(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})'
 
 ]

--- a/grammars/repositories/inlines/characters-grammar.cson
+++ b/grammars/repositories/inlines/characters-grammar.cson
@@ -9,7 +9,7 @@ patterns: [
   #   Dungeons &amp; Dragons
   #
   name: 'markup.htmlentity.asciidoc'
-  match: '(\&)(\\S+?)(;)'
+  match: '(?<!\\\\)(\&)(\\S+?)(;)'
   captures:
     1: name: 'support.constant.asciidoc'
     3: name: 'support.constant.asciidoc'

--- a/grammars/repositories/inlines/image-macro-grammar.cson
+++ b/grammars/repositories/inlines/image-macro-grammar.cson
@@ -12,7 +12,7 @@ patterns: [
   #   icon:github[large]
   #
   name: 'markup.macro.inline.image.general.asciidoc'
-  match: '\\\\?(?:image|icon):([^:\\[][^\\[]*)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])'
+  match: '(?<!\\\\)(?:image|icon):([^:\\[][^\\[]*)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])'
   captures:
     1: name: 'support.constant.asciidoc'
     2: name: 'support.constant.asciidoc'

--- a/grammars/repositories/inlines/kbd-macro-grammar.cson
+++ b/grammars/repositories/inlines/kbd-macro-grammar.cson
@@ -13,7 +13,7 @@ patterns: [
   #   btn:[Save]
   #
   name: 'markup.macro.inline.kbd.general.asciidoc'
-  match: '\\\\?(?:kbd|btn):(\\[)((?:\\\\\\]|[^\\]])+?)(\\])'
+  match: '(?<!\\\\)(?:kbd|btn):(\\[)((?:\\\\\\]|[^\\]])+?)(\\])'
   captures:
     2: name: 'support.constant.asciidoc'
 ]

--- a/grammars/repositories/inlines/link-macro-grammar.cson
+++ b/grammars/repositories/inlines/link-macro-grammar.cson
@@ -21,7 +21,7 @@ patterns: [
   #   mailto:doc.writer@example.com[]
   #
   name: 'markup.link.inline.asciidoc'
-  match: '\\\\?(?:link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
+  match: '(?<!\\\\)(?:link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
   captures:
     1: name: 'support.constant.link.inline.asciidoc'
 ,

--- a/grammars/repositories/inlines/menu-macro-grammar.cson
+++ b/grammars/repositories/inlines/menu-macro-grammar.cson
@@ -11,7 +11,7 @@ patterns: [
   #   menu:View[Page Style, No Style]
   #
   name: 'markup.link.menu.inline.asciidoc'
-  match: '\\\\?menu:(\\p{Word}|\\p{Word}.*?\\S)\\[\\p{Blank}*(.+?)?\\]'
+  match: '(?<!\\\\)menu:(\\p{Word}|\\p{Word}.*?\\S)\\[\\p{Blank}*(.+?)?\\]'
   captures:
     1: name: 'support.constant.menu.inline.asciidoc'
 ]

--- a/grammars/repositories/inlines/stem-grammar.cson
+++ b/grammars/repositories/inlines/stem-grammar.cson
@@ -11,7 +11,7 @@ patterns: [
   #   latexmath:[\sqrt{4} = 2]
   #
   name: 'markup.macro.inline.stem.general.asciidoc'
-  match: '\\\\?(stem|(?:latex|ascii)math):([a-z,]*)(\\[)(.*?[^\\\\])(\\])'
+  match: '(?<!\\\\)(stem|(?:latex|ascii)math):([a-z,]*)(\\[)(.*?[^\\\\])(\\])'
   captures:
     2: name: 'support.constant.asciidoc'
     4: name: 'support.constant.asciidoc'


### PR DESCRIPTION
## Description

Preventing substitutions:
- characters
- attribute reference
- anchor macro
- image macro
- kbd macro
- link macro
- menu macro
- stem macro

## Syntax example

```adoc
\&sect; will appear as an entity, not the &sect; symbol. FAILED
\{two-semicolons} will appear {two-semicolons}, not resolved as ;;. FAILED

\[[idname]] foo  [[idname]]
\anchor:idname[] foo anchor:idname[]
\stem:[x != 0] foo stem:[x != 0]
\asciimath:[x != 0] foo asciimath:[x != 0]
\latexmath:[\sqrt(1) = 2] foo latexmath:[\sqrt(1) = 2]
\kbd:[Save] foo kbd:[Save]
\menu:File[New...] foo menu:File[New...]
\link:path[label] foo link:path[label]
```

## Screenshots

![capture du 2016-05-12 14-33-33](https://cloud.githubusercontent.com/assets/5674651/15214651/8a502f2a-184e-11e6-97eb-de4960cf6145.png)

