### PR TITLE
feat: checklist snippets

### DIFF
--- a/snippets/language-asciidoc.cson
+++ b/snippets/language-asciidoc.cson
@@ -281,3 +281,13 @@
     descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#callouts'
     prefix: 'co'
     body: '<$1> $0'
+  'Unchecked':
+    description: 'Unchecked checklist item'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#checklist'
+    prefix: '-o'
+    body: '- [ ] $0'
+  'Checked':
+    description: 'Checked checklist item'
+    descriptionMoreURL: 'http://asciidoctor.org/docs/user-manual/#checklist'
+    prefix: '-x'
+    body: '- [x] $0'


### PR DESCRIPTION
Two snippets for the easy creation of both unchecked and checked checklist items.
Originally I was aiming for the `-[` snippet, but that raises issues if the editor automatically closes the first `[` bracket with a second `]` bracket after the cursor. Using the lower-case characters `o` and `x` resolve this, whilst symbolizing the check rendering.
<img width="231" alt="screen shot 2016-05-12 at 19 56 08" src="https://cloud.githubusercontent.com/assets/7458098/15224807/bbc4e0b4-187b-11e6-8221-1a7ba9abf48c.png">
