### PR TITLE
feat: url with attributes references

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -150,7 +150,41 @@ repository:
     patterns: [
       {
         name: "meta.definition.attribute-entry.asciidoc"
-        match: "^(:)(!?\\w[\\p{Blank}\\w-]*?|\\w[\\p{Blank}\\w-]*?!?)(:)(\\p{Blank}+.*)?$"
+        begin: "^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}\\+)$"
+        beginCaptures:
+          "1":
+            name: "punctuation.separator.attribute-entry.asciidoc"
+          "2":
+            name: "support.constant.attribute-name.asciidoc"
+          "3":
+            name: "punctuation.separator.attribute-entry.asciidoc"
+          "4":
+            name: "string.unquoted.attribute-value.asciidoc"
+            patterns: [
+              {
+                include: "#inlines"
+              }
+              {
+                include: "#line-break"
+              }
+            ]
+        contentName: "string.unquoted.attribute-value.asciidoc"
+        patterns: [
+          {
+            include: "#inlines"
+          }
+          {
+            include: "#line-break"
+          }
+        ]
+        end: "^\\p{Blank}+.+$(?<!\\+)|^\\p{Blank}*$"
+        endCaptures:
+          "0":
+            name: "string.unquoted.attribute-value.asciidoc"
+      }
+      {
+        name: "meta.definition.attribute-entry.asciidoc"
+        match: "^(:)(!?\\w.*?)(:)(\\p{Blank}+(.*))?$"
         captures:
           "1":
             name: "punctuation.separator.asciidoc"
@@ -160,6 +194,14 @@ repository:
             name: "punctuation.separator.asciidoc"
           "4":
             name: "string.unquoted.attribute-value.asciidoc"
+            patterns: [
+              {
+                include: "#inlines"
+              }
+              {
+                include: "#line-break"
+              }
+            ]
       }
     ]
   "block-callout":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -150,7 +150,7 @@ repository:
     patterns: [
       {
         name: "meta.definition.attribute-entry.asciidoc"
-        begin: "^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}\\+)$"
+        begin: "^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}(?:\\+|\\\\))$"
         beginCaptures:
           "1":
             name: "punctuation.separator.attribute-entry.asciidoc"
@@ -165,7 +165,13 @@ repository:
                 include: "#inlines"
               }
               {
+                include: "#hard-break-backslash"
+              }
+              {
                 include: "#line-break"
+              }
+              {
+                include: "#line-break-backslash"
               }
             ]
         contentName: "string.unquoted.attribute-value.asciidoc"
@@ -174,10 +180,16 @@ repository:
             include: "#inlines"
           }
           {
+            include: "#hard-break-backslash"
+          }
+          {
             include: "#line-break"
           }
+          {
+            include: "#line-break-backslash"
+          }
         ]
-        end: "^\\p{Blank}+.+$(?<!\\+)|^\\p{Blank}*$"
+        end: "^\\p{Blank}+.+$(?<!\\+|\\\\)|^\\p{Blank}*$"
         endCaptures:
           "0":
             name: "string.unquoted.attribute-value.asciidoc"
@@ -275,11 +287,29 @@ repository:
             name: "entity.name.function.asciidoc"
       }
     ]
+  "hard-break-backslash":
+    patterns: [
+      {
+        match: "(?<=\\S)\\p{Blank}+(\\+ \\\\)$"
+        captures:
+          "1":
+            name: "constant.other.symbol.hard-break.asciidoc"
+      }
+    ]
   "horizontal-rule":
     patterns: [
       {
         name: "constant.other.symbol.horizontal-rule.asciidoc"
         match: "^(?:'|<){3,}$|^ {0,3}([-\\*'])( *)\\1\\2\\1$"
+      }
+    ]
+  "line-break-backslash":
+    patterns: [
+      {
+        match: "(?<=\\S)\\p{Blank}+(\\\\)$"
+        captures:
+          "1":
+            name: "variable.line-break.asciidoc"
       }
     ]
   "line-break":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -153,11 +153,11 @@ repository:
         match: "^(:)(!?\\w[\\p{Blank}\\w-]*?|\\w[\\p{Blank}\\w-]*?!?)(:)(\\p{Blank}+.*)?$"
         captures:
           "1":
-            name: "punctuation.separator.attribute-entry.asciidoc"
+            name: "punctuation.separator.asciidoc"
           "2":
             name: "support.constant.attribute-name.asciidoc"
           "3":
-            name: "punctuation.separator.attribute-entry.asciidoc"
+            name: "punctuation.separator.asciidoc"
           "4":
             name: "string.unquoted.attribute-value.asciidoc"
       }

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -556,7 +556,7 @@ repository:
       }
       {
         name: "markup.other.url.asciidoc"
-        match: "(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?"
+        match: "(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
         captures:
           "1":
             name: "entity.name.function.asciidoc"

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -409,7 +409,7 @@ repository:
     patterns: [
       {
         name: "markup.substitution.attribute-reference.asciidoc"
-        match: "(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})"
+        match: "(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})"
       }
     ]
   "bibliography-anchor":
@@ -533,23 +533,40 @@ repository:
     patterns: [
       {
         name: "markup.other.url.asciidoc"
-        match: "(^|link:|<|[\\s>\\(\\)\\[\\];])((?<!\\\\)(?:https?|file|ftp|irc)://[^\\s\\[\\]<]*[^\\s.,\\[\\]<])(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?"
+        match: "(?:^|<|[\\s>\\(\\)\\[\\];])((?<!\\\\)(?:https?|file|ftp|irc)://[^\\s\\[\\]<]*[^\\s.,\\[\\]<\\)])(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?"
         captures:
           "1":
-            name: "entity.name.function.asciidoc"
-          "2":
             name: "markup.link.asciidoc"
-          "3":
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
+          "2":
             name: "string.unquoted.asciidoc"
       }
       {
         name: "markup.other.url.asciidoc"
-        match: "(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
+        match: "(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
+        captures:
+          "1":
+            name: "markup.substitution.attribute-reference.asciidoc"
+          "2":
+            name: "string.unquoted.asciidoc"
+      }
+      {
+        name: "markup.other.url.asciidoc"
+        match: "(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?"
         captures:
           "1":
             name: "entity.name.function.asciidoc"
           "2":
             name: "markup.link.asciidoc"
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
           "3":
             name: "string.unquoted.asciidoc"
       }

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -547,7 +547,7 @@ repository:
       }
       {
         name: "markup.other.url.asciidoc"
-        match: "(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
+        match: "(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{uri-\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])"
         captures:
           "1":
             name: "markup.substitution.attribute-reference.asciidoc"

--- a/grammars/repositories/inlines/attribute-reference-grammar.cson
+++ b/grammars/repositories/inlines/attribute-reference-grammar.cson
@@ -12,6 +12,6 @@ patterns: [
   #   {set:name!}
   #
   name: 'markup.substitution.attribute-reference.asciidoc'
-  match: '(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(\\\\)?(\\})'
+  match: '(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})'
 
 ]

--- a/grammars/repositories/inlines/link-macro-grammar.cson
+++ b/grammars/repositories/inlines/link-macro-grammar.cson
@@ -38,7 +38,7 @@ patterns: [
   #   mailto:doc.writer@example.com[]
   #
   name: 'markup.other.url.asciidoc'
-  match: '(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?'
+  match: '(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
   captures:
     1: name: 'entity.name.function.asciidoc'
     2:

--- a/grammars/repositories/inlines/link-macro-grammar.cson
+++ b/grammars/repositories/inlines/link-macro-grammar.cson
@@ -20,13 +20,14 @@ patterns: [
     2: name: 'string.unquoted.asciidoc'
 ,
   # Matches an implicit link with only attribute reference.
+  # attribute must beginning with `uri-`
   #
   # Examples
   #
   #   {uri-repo}[GitHub]
   #
   name: 'markup.other.url.asciidoc'
-  match: '(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
+  match: '(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{uri-\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
   captures:
     1: name: 'markup.substitution.attribute-reference.asciidoc'
     2: name: 'string.unquoted.asciidoc'

--- a/grammars/repositories/inlines/link-macro-grammar.cson
+++ b/grammars/repositories/inlines/link-macro-grammar.cson
@@ -10,11 +10,26 @@ patterns: [
   #   http://github.com[GitHub]
   #
   name: 'markup.other.url.asciidoc'
-  match: '(^|link:|<|[\\s>\\(\\)\\[\\];])((?<!\\\\)(?:https?|file|ftp|irc)://[^\\s\\[\\]<]*[^\\s.,\\[\\]<])(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?'
+  match: '(?:^|<|[\\s>\\(\\)\\[\\];])((?<!\\\\)(?:https?|file|ftp|irc)://[^\\s\\[\\]<]*[^\\s.,\\[\\]<\\)])(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?'
   captures:
-    1: name: 'entity.name.function.asciidoc'
-    2: name: 'markup.link.asciidoc'
-    3: name: 'string.unquoted.asciidoc'
+    1:
+      name: 'markup.link.asciidoc'
+      patterns: [
+        include: '#attribute-reference'
+      ]
+    2: name: 'string.unquoted.asciidoc'
+,
+  # Matches an implicit link with only attribute reference.
+  #
+  # Examples
+  #
+  #   {uri-repo}[GitHub]
+  #
+  name: 'markup.other.url.asciidoc'
+  match: '(?:^|<|[\\p{Blank}>\\(\\)\\[\\];])((?<!\\\\)\\{\\w+(?:[\\-]\\w+)*(?<!\\\\)\\})(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
+  captures:
+    1: name: 'markup.substitution.attribute-reference.asciidoc'
+    2: name: 'string.unquoted.asciidoc'
 ,
   # Match a link or e-mail inline macro
   # Examples
@@ -23,10 +38,14 @@ patterns: [
   #   mailto:doc.writer@example.com[]
   #
   name: 'markup.other.url.asciidoc'
-  match: '(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])'
+  match: '(?<!\\\\)(link|mailto):([^\\s\\[]+)(?:\\[((?:\\\\\\]|[^\\]])*?)\\])?'
   captures:
     1: name: 'entity.name.function.asciidoc'
-    2: name: 'markup.link.asciidoc'
+    2:
+      name: 'markup.link.asciidoc'
+      patterns: [
+        include: '#attribute-reference'
+      ]
     3: name: 'string.unquoted.asciidoc'
 ,
   # Matches an inline e-mail address.

--- a/grammars/repositories/partials/attributes-grammar.cson
+++ b/grammars/repositories/partials/attributes-grammar.cson
@@ -13,8 +13,8 @@ patterns: [
   name: 'meta.definition.attribute-entry.asciidoc'
   match: '^(:)(!?\\w[\\p{Blank}\\w-]*?|\\w[\\p{Blank}\\w-]*?!?)(:)(\\p{Blank}+.*)?$'
   captures:
-    1: name: 'punctuation.separator.attribute-entry.asciidoc'
+    1: name: 'punctuation.separator.asciidoc'
     2: name: 'support.constant.attribute-name.asciidoc'
-    3: name: 'punctuation.separator.attribute-entry.asciidoc'
+    3: name: 'punctuation.separator.asciidoc'
     4: name: 'string.unquoted.attribute-value.asciidoc'
 ]

--- a/grammars/repositories/partials/attributes-grammar.cson
+++ b/grammars/repositories/partials/attributes-grammar.cson
@@ -7,11 +7,11 @@ patterns: [
   # Examples
   #
   #   :attr: foo +
-  #       foo +
+  #       foo + \
   #       bar
   #
   name: 'meta.definition.attribute-entry.asciidoc'
-  begin: '^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}\\+)$'
+  begin: '^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}(?:\\+|\\\\))$'
   beginCaptures:
     1: name: 'punctuation.separator.attribute-entry.asciidoc'
     2: name: 'support.constant.attribute-name.asciidoc'
@@ -21,15 +21,23 @@ patterns: [
       patterns: [
         include: '#inlines'
       ,
+        include: '#hard-break-backslash'
+      ,
         include: '#line-break'
+      ,
+        include: '#line-break-backslash'
       ]
   contentName: 'string.unquoted.attribute-value.asciidoc'
   patterns: [
     include: '#inlines'
   ,
+    include: '#hard-break-backslash'
+  ,
     include: '#line-break'
+  ,
+    include: '#line-break-backslash'
   ]
-  end: '^\\p{Blank}+.+$(?<!\\+)|^\\p{Blank}*$'
+  end: '^\\p{Blank}+.+$(?<!\\+|\\\\)|^\\p{Blank}*$'
   endCaptures:
     0: name: 'string.unquoted.attribute-value.asciidoc'
 ,

--- a/grammars/repositories/partials/attributes-grammar.cson
+++ b/grammars/repositories/partials/attributes-grammar.cson
@@ -2,6 +2,37 @@ key: 'attribute-entry'
 
 patterns: [
 
+  # Matches attributes (multi-lines)
+  #
+  # Examples
+  #
+  #   :attr: foo +
+  #       foo +
+  #       bar
+  #
+  name: 'meta.definition.attribute-entry.asciidoc'
+  begin: '^(:)(!?\\w.*?)(:)(\\p{Blank}+.+\\p{Blank}\\+)$'
+  beginCaptures:
+    1: name: 'punctuation.separator.attribute-entry.asciidoc'
+    2: name: 'support.constant.attribute-name.asciidoc'
+    3: name: 'punctuation.separator.attribute-entry.asciidoc'
+    4:
+      name: 'string.unquoted.attribute-value.asciidoc'
+      patterns: [
+        include: '#inlines'
+      ,
+        include: '#line-break'
+      ]
+  contentName: 'string.unquoted.attribute-value.asciidoc'
+  patterns: [
+    include: '#inlines'
+  ,
+    include: '#line-break'
+  ]
+  end: '^\\p{Blank}+.+$(?<!\\+)|^\\p{Blank}*$'
+  endCaptures:
+    0: name: 'string.unquoted.attribute-value.asciidoc'
+,
   # Matches attributes
   #
   # Examples
@@ -11,10 +42,16 @@ patterns: [
   #   :!compat-mode:
   #
   name: 'meta.definition.attribute-entry.asciidoc'
-  match: '^(:)(!?\\w[\\p{Blank}\\w-]*?|\\w[\\p{Blank}\\w-]*?!?)(:)(\\p{Blank}+.*)?$'
+  match: '^(:)(!?\\w.*?)(:)(\\p{Blank}+(.*))?$'
   captures:
     1: name: 'punctuation.separator.asciidoc'
     2: name: 'support.constant.attribute-name.asciidoc'
     3: name: 'punctuation.separator.asciidoc'
-    4: name: 'string.unquoted.attribute-value.asciidoc'
+    4:
+      name: 'string.unquoted.attribute-value.asciidoc'
+      patterns: [
+        include: '#inlines'
+      ,
+        include: '#line-break'
+      ]
 ]

--- a/grammars/repositories/partials/hard-break-backslash-grammar.cson
+++ b/grammars/repositories/partials/hard-break-backslash-grammar.cson
@@ -1,0 +1,7 @@
+key: 'hard-break-backslash'
+
+patterns: [
+    match: '(?<=\\S)\\p{Blank}+(\\+ \\\\)$'
+    captures:
+      1: name: 'constant.other.symbol.hard-break.asciidoc'
+]

--- a/grammars/repositories/partials/line-break-backslash-grammar.cson
+++ b/grammars/repositories/partials/line-break-backslash-grammar.cson
@@ -1,0 +1,7 @@
+key: 'line-break-backslash'
+
+patterns: [
+  match: '(?<=\\S)\\p{Blank}+(\\\\)$'
+  captures:
+    1: name: 'variable.line-break.asciidoc'
+]

--- a/spec/inlines/attribute-reference-grammar-spec.coffee
+++ b/spec/inlines/attribute-reference-grammar-spec.coffee
@@ -36,3 +36,15 @@ describe 'Should tokenizes inline attribute-reference when', ->
     expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
     expect(tokens[1]).toEqualJson value: '{set:foo:bar}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
     expect(tokens[2]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+
+  describe 'Should not tokenizes inline attribute-reference when', ->
+
+    it '"{" escaped', ->
+      {tokens} = grammar.tokenizeLine 'foobar \\\\{mylink} foobar'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: 'foobar \\\\{mylink} foobar', scopes: ['source.asciidoc']
+
+    it '"}" escaped', ->
+      {tokens} = grammar.tokenizeLine 'foobar {mylink\\\} foobar'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: 'foobar {mylink\\\} foobar', scopes: ['source.asciidoc']

--- a/spec/inlines/link-grammar-spec.coffee
+++ b/spec/inlines/link-grammar-spec.coffee
@@ -189,3 +189,10 @@ describe 'Should tokenizes text link when', ->
       expect(tokens[4]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
       expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
       expect(tokens[6]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+
+    it 'attribute reference doesn\'t contains "uri-" (invalid context)', ->
+      {tokens} = grammar.tokenizeLine 'foo {foo}[bar] bar'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{foo}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[bar] bar', scopes: ['source.asciidoc']

--- a/spec/inlines/link-grammar-spec.coffee
+++ b/spec/inlines/link-grammar-spec.coffee
@@ -84,15 +84,6 @@ describe 'Should tokenizes text link when', ->
 
   describe '"link:" & "mailto:" macro', ->
 
-    it 'is a simple url with https started with "link:"', ->
-      {tokens} = grammar.tokenizeLine 'Go on link:https://foobar.com now'
-      expect(tokens).toHaveLength 5
-      expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-      expect(tokens[3]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-      expect(tokens[4]).toEqualJson value: ' now', scopes: ['source.asciidoc']
-
     it 'have optional link text and attributes', ->
       {tokens} = grammar.tokenizeLine 'Go on link:url[optional link text, optional target attribute, optional role attribute] now'
       expect(tokens).toHaveLength 8
@@ -127,6 +118,11 @@ describe 'Should tokenizes text link when', ->
       expect(tokens[6]).toEqualJson value: 'label', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
       expect(tokens[7]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
       expect(tokens[8]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+
+    it 'is a simple url with https started with "link:" with missing square brackets ending (invalid context)', ->
+      {tokens} = grammar.tokenizeLine 'Go on link:https://foobar.com now'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: 'Go on link:https://foobar.com now', scopes: ['source.asciidoc']
 
   describe 'email pattern', ->
 

--- a/spec/inlines/link-grammar-spec.coffee
+++ b/spec/inlines/link-grammar-spec.coffee
@@ -16,95 +16,180 @@ describe 'Should tokenizes text link when', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'is a simple url with http', ->
-    {tokens} = grammar.tokenizeLine 'http://www.docbook.org/[DocBook.org]'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'http://www.docbook.org/', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[1]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'DocBook.org', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+  describe 'URL pattern', ->
 
-  it 'is a simple url with http in phrase', ->
-    {tokens} = grammar.tokenizeLine 'Go on http://foobar.com now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'http://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with http', ->
+      {tokens} = grammar.tokenizeLine 'http://www.docbook.org/[DocBook.org]'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'http://www.docbook.org/', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'DocBook.org', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
 
-  it 'is a simple url with https', ->
-    {tokens} = grammar.tokenizeLine 'Go on https://foobar.com now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with http in phrase', ->
+      {tokens} = grammar.tokenizeLine 'Go on http://foobar.com now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'http://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple url with file', ->
-    {tokens} = grammar.tokenizeLine 'Go on file://foobar.txt now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'file://foobar.txt', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with https', ->
+      {tokens} = grammar.tokenizeLine 'Go on https://foobar.com now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple url with ftp', ->
-    {tokens} = grammar.tokenizeLine 'Go on ftp://foobar.txt now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'ftp://foobar.txt', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with file', ->
+      {tokens} = grammar.tokenizeLine 'Go on file://foobar.txt now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'file://foobar.txt', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple url with irc', ->
-    {tokens} = grammar.tokenizeLine 'Go on irc://foobar now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'irc://foobar', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with ftp', ->
+      {tokens} = grammar.tokenizeLine 'Go on ftp://foobar.txt now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'ftp://foobar.txt', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple url with https started with "link:"', ->
-    {tokens} = grammar.tokenizeLine 'Go on link:https://foobar.com now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'link:', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url with irc', ->
+      {tokens} = grammar.tokenizeLine 'Go on irc://foobar now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'Go on', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'irc://foobar', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple url in a bullet list', ->
-    {tokens} = grammar.tokenizeLine '* https://foobar.com now'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
-    expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'is a simple url in a bullet list', ->
+      {tokens} = grammar.tokenizeLine '* https://foobar.com now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'have optional link text and attributes', ->
-    {tokens} = grammar.tokenizeLine 'Go on link:url[optional link text, optional target attribute, optional role attribute] now'
-    expect(tokens).toHaveLength 8
-    expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'url', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'optional link text, optional target attribute, optional role attribute', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+    it 'contains attribute reference', ->
+      {tokens} = grammar.tokenizeLine 'http://foo{uri-repo}bar.com now'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'http://foo', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'bar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' now', scopes: ['source.asciidoc']
 
-  it 'is a simple mailto', ->
-    {tokens} = grammar.tokenizeLine 'Go on mailto:doc.writer@example.com[] now'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'mailto', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'doc.writer@example.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[]', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+  describe '"link:" & "mailto:" macro', ->
 
-  it 'is a email', ->
-    {tokens} = grammar.tokenizeLine 'foo doc.writer@example.com bar'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'doc.writer@example.com', scopes: ['source.asciidoc', 'markup.link.email.asciidoc']
-    expect(tokens[2]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'is a simple url with https started with "link:"', ->
+      {tokens} = grammar.tokenizeLine 'Go on link:https://foobar.com now'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'https://foobar.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+
+    it 'have optional link text and attributes', ->
+      {tokens} = grammar.tokenizeLine 'Go on link:url[optional link text, optional target attribute, optional role attribute] now'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'url', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'optional link text, optional target attribute, optional role attribute', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+
+    it 'is a simple mailto', ->
+      {tokens} = grammar.tokenizeLine 'Go on mailto:doc.writer@example.com[] now'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'mailto', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'doc.writer@example.com', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[]', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+
+    it 'contains attribute reference', ->
+      {tokens} = grammar.tokenizeLine 'Go on link:http://{uri-repo}[label] now'
+      expect(tokens).toHaveLength 9
+      expect(tokens[0]).toEqualJson value: 'Go on ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'http://', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[5]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[6]).toEqualJson value: 'label', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[7]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[8]).toEqualJson value: ' now', scopes: ['source.asciidoc']
+
+  describe 'email pattern', ->
+
+    it 'is a email', ->
+      {tokens} = grammar.tokenizeLine 'foo doc.writer@example.com bar'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'doc.writer@example.com', scopes: ['source.asciidoc', 'markup.link.email.asciidoc']
+      expect(tokens[2]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+
+  describe 'pure attribute reference link', ->
+
+    it 'start at the beginning of the line', ->
+      {tokens} = grammar.tokenizeLine '{uri-repo}[Asciidoctor]'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+
+    it 'start with "["', ->
+      {tokens} = grammar.tokenizeLine '[{uri-repo}[Asciidoctor]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+
+    it 'start with "("', ->
+      {tokens} = grammar.tokenizeLine '({uri-repo}[Asciidoctor]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '(', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+
+    it 'start with "<"', ->
+      {tokens} = grammar.tokenizeLine '<{uri-repo}[Asciidoctor]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+
+    it 'start with ">"', ->
+      {tokens} = grammar.tokenizeLine '>{uri-repo}[Asciidoctor]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+
+    it 'is in a phrase', ->
+      {tokens} = grammar.tokenizeLine 'foo {uri-repo}[Asciidoctor] bar'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqualJson value: 'foo', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[2]).toEqualJson value: '{uri-repo}', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Asciidoctor', scopes: ['source.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[6]).toEqualJson value: ' bar', scopes: ['source.asciidoc']

--- a/spec/partials/attributes-grammar-spec.coffee
+++ b/spec/partials/attributes-grammar-spec.coffee
@@ -19,21 +19,21 @@ describe 'Should tokenizes attributes when', ->
   it 'simple attributes not following with text', ->
     {tokens} = grammar.tokenizeLine ':sectanchors:'
     expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-    expect(tokens[1]).toEqual value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[1]).toEqualJson value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
 
   it 'following with text', ->
     {tokens} = grammar.tokenizeLine ':icons: font'
     expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-    expect(tokens[1]).toEqual value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-    expect(tokens[3]).toEqual value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[1]).toEqualJson value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[3]).toEqualJson value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
 
   it 'contains negate', ->
     {tokens} = grammar.tokenizeLine ':!compat-mode:'
     expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-    expect(tokens[1]).toEqual value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqual value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[1]).toEqualJson value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']

--- a/spec/partials/attributes-grammar-spec.coffee
+++ b/spec/partials/attributes-grammar-spec.coffee
@@ -16,24 +16,65 @@ describe 'Should tokenizes attributes when', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple attributes not following with text', ->
-    {tokens} = grammar.tokenizeLine ':sectanchors:'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+  describe 'single-line', ->
 
-  it 'following with text', ->
-    {tokens} = grammar.tokenizeLine ':icons: font'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+    it 'simple attributes not following with text', ->
+      {tokens} = grammar.tokenizeLine ':sectanchors:'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
 
-  it 'contains negate', ->
-    {tokens} = grammar.tokenizeLine ':!compat-mode:'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[1]).toEqualJson value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    it 'following with text', ->
+      {tokens} = grammar.tokenizeLine ':icons: font'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+
+    it 'contains negate', ->
+      {tokens} = grammar.tokenizeLine ':!compat-mode:'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[1]).toEqualJson value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+
+    it 'contains an URL', ->
+      {tokens} = grammar.tokenizeLine ':homepage: http://asciidoctor.org'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'homepage', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+
+  describe 'multi-lines', ->
+
+    it 'contains link', ->
+      tokens = grammar.tokenizeLines '''
+        :description: foo bar +
+          foo link:http://asciidoctor.org[AsciiDoctor] bar +
+          text and text
+        '''
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toHaveLength 6
+      expect(tokens[0][0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: 'description', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+      expect(tokens[0][3]).toEqualJson value: ' foo bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[0][4]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[0][5]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+      expect(tokens[1]).toHaveLength 10
+      expect(tokens[1][0]).toEqualJson value: '  foo ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[1][1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1][3]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[1][4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1][5]).toEqualJson value: 'AsciiDoctor', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[1][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[1][7]).toEqualJson value: ' bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[1][8]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[1][9]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: '  text and text', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']

--- a/spec/partials/attributes-grammar-spec.coffee
+++ b/spec/partials/attributes-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes attributes when', ->
+describe 'Attributes', ->
   grammar = null
 
   beforeEach ->
@@ -16,65 +16,123 @@ describe 'Should tokenizes attributes when', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  describe 'single-line', ->
+  describe 'Should tokenizes when', ->
 
-    it 'simple attributes not following with text', ->
-      {tokens} = grammar.tokenizeLine ':sectanchors:'
-      expect(tokens).toHaveLength 3
-      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[1]).toEqualJson value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+    describe 'single-line', ->
 
-    it 'following with text', ->
-      {tokens} = grammar.tokenizeLine ':icons: font'
-      expect(tokens).toHaveLength 4
-      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[1]).toEqualJson value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[3]).toEqualJson value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      it 'simple attributes not following with text', ->
+        {tokens} = grammar.tokenizeLine ':sectanchors:'
+        expect(tokens).toHaveLength 3
+        expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[1]).toEqualJson value: 'sectanchors', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
 
-    it 'contains negate', ->
-      {tokens} = grammar.tokenizeLine ':!compat-mode:'
-      expect(tokens).toHaveLength 3
-      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[1]).toEqualJson value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+      it 'following with text', ->
+        {tokens} = grammar.tokenizeLine ':icons: font'
+        expect(tokens).toHaveLength 4
+        expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[1]).toEqualJson value: 'icons', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[3]).toEqualJson value: ' font', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
 
-    it 'contains an URL', ->
-      {tokens} = grammar.tokenizeLine ':homepage: http://asciidoctor.org'
-      expect(tokens).toHaveLength 5
-      expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[1]).toEqualJson value: 'homepage', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
-      expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
-      expect(tokens[4]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+      it 'contains negate', ->
+        {tokens} = grammar.tokenizeLine ':!compat-mode:'
+        expect(tokens).toHaveLength 3
+        expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[1]).toEqualJson value: '!compat-mode', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
 
-  describe 'multi-lines', ->
+      it 'contains an URL', ->
+        {tokens} = grammar.tokenizeLine ':homepage: http://asciidoctor.org'
+        expect(tokens).toHaveLength 5
+        expect(tokens[0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[1]).toEqualJson value: 'homepage', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.asciidoc']
+        expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[4]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
 
-    it 'contains link', ->
-      tokens = grammar.tokenizeLines '''
-        :description: foo bar +
-          foo link:http://asciidoctor.org[AsciiDoctor] bar +
-          text and text
-        '''
-      expect(tokens).toHaveLength 3
-      expect(tokens[0]).toHaveLength 6
-      expect(tokens[0][0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-      expect(tokens[0][1]).toEqualJson value: 'description', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
-      expect(tokens[0][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
-      expect(tokens[0][3]).toEqualJson value: ' foo bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
-      expect(tokens[0][4]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
-      expect(tokens[0][5]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
-      expect(tokens[1]).toHaveLength 10
-      expect(tokens[1][0]).toEqualJson value: '  foo ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
-      expect(tokens[1][1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
-      expect(tokens[1][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
-      expect(tokens[1][3]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
-      expect(tokens[1][4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
-      expect(tokens[1][5]).toEqualJson value: 'AsciiDoctor', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
-      expect(tokens[1][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
-      expect(tokens[1][7]).toEqualJson value: ' bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
-      expect(tokens[1][8]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
-      expect(tokens[1][9]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
-      expect(tokens[2]).toHaveLength 1
-      expect(tokens[2][0]).toEqualJson value: '  text and text', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+    describe 'multi-lines', ->
+
+      it 'contains link', ->
+        tokens = grammar.tokenizeLines '''
+          :description: foo bar +
+            foo link:http://asciidoctor.org[AsciiDoctor] bar +
+            text and text
+          '''
+        expect(tokens).toHaveLength 3
+        expect(tokens[0]).toHaveLength 6
+        expect(tokens[0][0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][1]).toEqualJson value: 'description', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[0][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][3]).toEqualJson value: ' foo bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][4]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][5]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+        expect(tokens[1]).toHaveLength 10
+        expect(tokens[1][0]).toEqualJson value: '  foo ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+        expect(tokens[1][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][3]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+        expect(tokens[1][4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][5]).toEqualJson value: 'AsciiDoctor', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+        expect(tokens[1][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][7]).toEqualJson value: ' bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][8]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][9]).toEqualJson value: '+', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+        expect(tokens[2]).toHaveLength 1
+        expect(tokens[2][0]).toEqualJson value: '  text and text', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+
+      it 'contains line-break backslash', ->
+        tokens = grammar.tokenizeLines '''
+          :description: foo bar \\
+            foo link:http://asciidoctor.org[AsciiDoctor] bar \\
+            text and text
+          '''
+        expect(tokens).toHaveLength 3
+        expect(tokens[0]).toHaveLength 6
+        expect(tokens[0][0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][1]).toEqualJson value: 'description', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[0][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][3]).toEqualJson value: ' foo bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][4]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][5]).toEqualJson value: '\\', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+        expect(tokens[1]).toHaveLength 10
+        expect(tokens[1][0]).toEqualJson value: '  foo ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+        expect(tokens[1][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][3]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+        expect(tokens[1][4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][5]).toEqualJson value: 'AsciiDoctor', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+        expect(tokens[1][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][7]).toEqualJson value: ' bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][8]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][9]).toEqualJson value: '\\', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'variable.line-break.asciidoc']
+        expect(tokens[2]).toHaveLength 1
+        expect(tokens[2][0]).toEqualJson value: '  text and text', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+
+      it 'contains hard-break backslash', ->
+        tokens = grammar.tokenizeLines '''
+          :description: foo bar + \\
+            foo link:http://asciidoctor.org[AsciiDoctor] bar + \\
+            text and text
+          '''
+        expect(tokens).toHaveLength 3
+        expect(tokens[0]).toHaveLength 6
+        expect(tokens[0][0]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][1]).toEqualJson value: 'description', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'support.constant.attribute-name.asciidoc']
+        expect(tokens[0][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'punctuation.separator.attribute-entry.asciidoc']
+        expect(tokens[0][3]).toEqualJson value: ' foo bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][4]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[0][5]).toEqualJson value: '+ \\', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'constant.other.symbol.hard-break.asciidoc']
+        expect(tokens[1]).toHaveLength 10
+        expect(tokens[1][0]).toEqualJson value: '  foo ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][1]).toEqualJson value: 'link', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'entity.name.function.asciidoc']
+        expect(tokens[1][2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][3]).toEqualJson value: 'http://asciidoctor.org', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'markup.link.asciidoc']
+        expect(tokens[1][4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][5]).toEqualJson value: 'AsciiDoctor', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+        expect(tokens[1][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'markup.other.url.asciidoc']
+        expect(tokens[1][7]).toEqualJson value: ' bar', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][8]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+        expect(tokens[1][9]).toEqualJson value: '+ \\', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc', 'constant.other.symbol.hard-break.asciidoc']
+        expect(tokens[2]).toHaveLength 1
+        expect(tokens[2][0]).toEqualJson value: '  text and text', scopes: ['source.asciidoc', 'meta.definition.attribute-entry.asciidoc', 'string.unquoted.attribute-value.asciidoc']


### PR DESCRIPTION
## Description

Use attributes references with url

## Syntax example

```adoc
{uri-repo}[Asciidoctor]
[{uri-repo}[Asciidoctor]
({uri-repo}[Asciidoctor]
<{uri-repo}[Asciidoctor]
>{uri-repo}[Asciidoctor]
foo {uri-repo}[Asciidoctor] bar

link:http://{uri-repo}[label]
[link:{uri-repo}[label]
(link:{uri-repo}[label]
<link:{uri-repo}[label]
>link:{uri-repo}[label]
foo link:{uri-repo}[label] bar
Go on link:https://foobar.com now

http://foo{uri-repo}bar.com
<http://foobar.com[foobar]
>http://foobar.com[foobar]
(http://foobar.com[foobar]
[http://foobar.com[foobar]
foo http://foobar.com[foobar] bar
```

## Screenshots

![capture du 2016-05-14 17-26-19](https://cloud.githubusercontent.com/assets/5674651/15269239/ffbd494a-19f8-11e6-93f7-e2e1a14c8fbb.png)


