### PR TITLE
feat: add mark support

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -709,12 +709,36 @@ repository:
     patterns: [
       {
         name: "markup.mark.unconstrained.asciidoc"
-        match: "(?<!\\\\\\\\)(\\[[^\\]]+?\\])?((##)(.+?)(##))"
+        match: "(?<!\\\\\\\\)(\\[[^\\]]+?\\])((##)(.+?)(##))"
         captures:
           "1":
             name: "markup.meta.attribute-list.asciidoc"
           "2":
+            name: "markup.mark.asciidoc"
+          "3":
+            name: "punctuation.definition.asciidoc"
+          "5":
+            name: "punctuation.definition.asciidoc"
+      }
+      {
+        name: "markup.mark.unconstrained.asciidoc"
+        match: "(?<!\\\\\\\\)((##)(.+?)(##))"
+        captures:
+          "1":
             name: "markup.highlight.asciidoc"
+          "2":
+            name: "punctuation.definition.asciidoc"
+          "4":
+            name: "punctuation.definition.asciidoc"
+      }
+      {
+        name: "markup.mark.constrained.asciidoc"
+        match: "(?<![\\\\;:\\p{Word}#])(\\[[^\\]]+?\\])((#)(\\S|\\S.*?\\S)(#)(?!\\p{Word}))"
+        captures:
+          "1":
+            name: "markup.meta.attribute-list.asciidoc"
+          "2":
+            name: "markup.mark.asciidoc"
           "3":
             name: "punctuation.definition.asciidoc"
           "5":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -155,6 +155,9 @@ repository:
         include: "#subscript"
       }
       {
+        include: "#mark"
+      }
+      {
         include: "#general-block-macro"
       }
       {
@@ -700,6 +703,35 @@ repository:
       {
         name: "markup.link.email.asciidoc"
         match: "\\p{Word}[\\p{Word}.%+-]*(@)\\p{Alnum}[\\p{Alnum}.-]*(\\.)\\p{Alpha}{2,4}\\b"
+      }
+    ]
+  mark:
+    patterns: [
+      {
+        name: "markup.mark.unconstrained.asciidoc"
+        match: "(?<!\\\\\\\\)(\\[[^\\]]+?\\])?((##)(.+?)(##))"
+        captures:
+          "1":
+            name: "markup.meta.attribute-list.asciidoc"
+          "2":
+            name: "markup.highlight.asciidoc"
+          "3":
+            name: "punctuation.definition.asciidoc"
+          "5":
+            name: "punctuation.definition.asciidoc"
+      }
+      {
+        name: "markup.mark.constrained.asciidoc"
+        match: "(?<![\\\\;:\\p{Word}#])(\\[[^\\]]+?\\])?((#)(\\S|\\S.*?\\S)(#)(?!\\p{Word}))"
+        captures:
+          "1":
+            name: "markup.meta.attribute-list.asciidoc"
+          "2":
+            name: "markup.highlight.asciidoc"
+          "3":
+            name: "punctuation.definition.asciidoc"
+          "5":
+            name: "punctuation.definition.asciidoc"
       }
     ]
   "menu-macro":

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -103,6 +103,8 @@ repository:
     ,
       include: '#subscript'
     ,
+      include: '#mark'
+    ,
       include: '#general-block-macro'
     ,
       include: '#anchor-macro'

--- a/grammars/repositories/inlines/mark-grammar.cson
+++ b/grammars/repositories/inlines/mark-grammar.cson
@@ -6,22 +6,48 @@ patterns: [
   #
   # Examples:
   #
+  #   m[role]##ark## phrase
+  #
+  name: 'markup.mark.unconstrained.asciidoc'
+  match: '(?<!\\\\\\\\)(\\[[^\\]]+?\\])((##)(.+?)(##))'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    2: name: 'markup.mark.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
+,
+  # Matches mark unconstrained phrases. (highlight)
+  #
+  # Examples:
+  #
   #   m##ark## phrase
   #
   name: 'markup.mark.unconstrained.asciidoc'
-  match: '(?<!\\\\\\\\)(\\[[^\\]]+?\\])?((##)(.+?)(##))'
+  match: '(?<!\\\\\\\\)((##)(.+?)(##))'
   captures:
-    1: name: 'markup.meta.attribute-list.asciidoc'
-    2: name: 'markup.highlight.asciidoc'
-    3: name: 'punctuation.definition.asciidoc'
-    5: name: 'punctuation.definition.asciidoc'
+    1: name: 'markup.highlight.asciidoc'
+    2: name: 'punctuation.definition.asciidoc'
+    4: name: 'punctuation.definition.asciidoc'
 ,
   # Matches mark constrained phrases
   #
   # Examples:
   #
-  #   #mark phrase#
   #   [smal]#mark phrase#
+  #
+  name: 'markup.mark.constrained.asciidoc'
+  match: '(?<![\\\\;:\\p{Word}#])(\\[[^\\]]+?\\])((#)(\\S|\\S.*?\\S)(#)(?!\\p{Word}))'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    2: name: 'markup.mark.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
+,
+  # Matches mark constrained phrases (highlight)
+  #
+  # Examples:
+  #
+  #   #mark phrase#
   #
   name: 'markup.mark.constrained.asciidoc'
   match: '(?<![\\\\;:\\p{Word}#])(\\[[^\\]]+?\\])?((#)(\\S|\\S.*?\\S)(#)(?!\\p{Word}))'

--- a/grammars/repositories/inlines/mark-grammar.cson
+++ b/grammars/repositories/inlines/mark-grammar.cson
@@ -1,0 +1,33 @@
+key: 'mark'
+
+patterns: [
+
+  # Matches mark unconstrained phrases
+  #
+  # Examples:
+  #
+  #   m##ark## phrase
+  #
+  name: 'markup.mark.unconstrained.asciidoc'
+  match: '(?<!\\\\\\\\)(\\[[^\\]]+?\\])?((##)(.+?)(##))'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    2: name: 'markup.highlight.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
+,
+  # Matches mark constrained phrases
+  #
+  # Examples:
+  #
+  #   #mark phrase#
+  #   [smal]#mark phrase#
+  #
+  name: 'markup.mark.constrained.asciidoc'
+  match: '(?<![\\\\;:\\p{Word}#])(\\[[^\\]]+?\\])?((#)(\\S|\\S.*?\\S)(#)(?!\\p{Word}))'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    2: name: 'markup.highlight.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
+]

--- a/spec/inlines/mark-grammar-spec.coffee
+++ b/spec/inlines/mark-grammar-spec.coffee
@@ -1,0 +1,181 @@
+describe 'mark text', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes constrained mark text', ->
+
+    it 'when constrained mark text', ->
+      {tokens} = grammar.tokenizeLine 'this is #mark# text'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'this is ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' text', scopes: ['source.asciidoc']
+
+    it 'when constrained mark at the beginning of the line', ->
+      {tokens} = grammar.tokenizeLine '#mark text# from the start.'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'mark text', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' from the start.', scopes: ['source.asciidoc']
+
+    it 'when constrained mark is escaped', ->
+      {tokens} = grammar.tokenizeLine '\\#mark text#'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: '\\#mark text#', scopes: ['source.asciidoc']
+
+    it 'when constrained mark in a *bulleted list', ->
+      {tokens} = grammar.tokenizeLine '* #mark text# followed by normal text'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'mark text', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[4]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' followed by normal text', scopes: ['source.asciidoc']
+
+    it 'when constrained mark text within special characters', ->
+      {tokens} = grammar.tokenizeLine 'a#non-mark#a, !#mark#?, \'#mark#:, .#mark#; ,#mark#'
+      expect(tokens).toHaveLength 16
+      expect(tokens[0]).toEqualJson value: 'a#non-mark#a, !', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[4]).toEqualJson value: '?, \'', scopes: ['source.asciidoc']
+      expect(tokens[5]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[6]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[7]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[8]).toEqualJson value: ':, .', scopes: ['source.asciidoc']
+      expect(tokens[9]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[10]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[11]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[12]).toEqualJson value: '; ,', scopes: ['source.asciidoc']
+      expect(tokens[13]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[14]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[15]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when text is "this is \\#mark\\# text"', ->
+      {tokens} = grammar.tokenizeLine 'this is #mark# text'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'this is ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' text', scopes: ['source.asciidoc']
+
+    it 'when text is "* text\\#"', ->
+      {tokens} = grammar.tokenizeLine '* text#'
+      expect(tokens).toHaveLength 2
+      expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' text#', scopes: ['source.asciidoc']
+
+    it 'when text is "\\#mark text\\#"', ->
+      {tokens} = grammar.tokenizeLine '#mark text#'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'mark text', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when text is "\\#mark\\#text\\#"', ->
+      {tokens} = grammar.tokenizeLine '#mark#text#'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'mark#text', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when text is "\\#mark\\# text \\#mark\\# text"', ->
+      {tokens} = grammar.tokenizeLine '#mark# text #mark# text'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' text ', scopes: ['source.asciidoc']
+      expect(tokens[4]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[6]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' text', scopes: ['source.asciidoc']
+
+    it 'when text is "* \\#mark\\# text" (list context)', ->
+      {tokens} = grammar.tokenizeLine '* #mark# text'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[4]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' text', scopes: ['source.asciidoc']
+
+    it 'when text is "* \\#mark\\#" (list context)', ->
+      {tokens} = grammar.tokenizeLine '* #mark#'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[1]).toEqualJson value: ' ', scopes: ['source.asciidoc']
+      expect(tokens[2]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[4]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when having a [role] set on constrained mark text', ->
+      {tokens} = grammar.tokenizeLine '[role]#mark#'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when having [role1 role2] set on constrained mark text', ->
+      {tokens} = grammar.tokenizeLine '[role1 role2]#mark#'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+  describe 'Should tokenizes unconstrained math text', ->
+
+    it 'when unconstrained mark text', ->
+      {tokens} = grammar.tokenizeLine 'this is##mark##text'
+      expect(tokens[0]).toEqualJson value: 'this is', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'text', scopes: ['source.asciidoc']
+
+    it 'when unconstrained mark text with asterisks', ->
+      {tokens} = grammar.tokenizeLine 'this is##mark#text##'
+      expect(tokens[0]).toEqualJson value: 'this is', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark#text', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when unconstrained mark is double escaped', ->
+      {tokens} = grammar.tokenizeLine '\\\\##mark text##'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: '\\\\##mark text##', scopes: ['source.asciidoc']
+
+    it 'when having a [role] set on unconstrained mark text', ->
+      {tokens} = grammar.tokenizeLine '[role]##mark##'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when having [role1 role2] set on unconstrained mark text', ->
+      {tokens} = grammar.tokenizeLine '[role1 role2]##mark##'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']

--- a/spec/inlines/mark-grammar-spec.coffee
+++ b/spec/inlines/mark-grammar-spec.coffee
@@ -130,17 +130,17 @@ describe 'mark text', ->
       {tokens} = grammar.tokenizeLine '[role]#mark#'
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
-      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
 
     it 'when having [role1 role2] set on constrained mark text', ->
       {tokens} = grammar.tokenizeLine '[role1 role2]#mark#'
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc']
-      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc']
+      expect(tokens[3]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.mark.constrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
 
   describe 'Should tokenizes unconstrained math text', ->
 
@@ -168,14 +168,14 @@ describe 'mark text', ->
       {tokens} = grammar.tokenizeLine '[role]##mark##'
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
-      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
 
     it 'when having [role1 role2] set on unconstrained mark text', ->
       {tokens} = grammar.tokenizeLine '[role1 role2]##mark##'
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc']
-      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.highlight.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'mark', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc']
+      expect(tokens[3]).toEqualJson value: '##', scopes: ['source.asciidoc', 'markup.mark.unconstrained.asciidoc', 'markup.mark.asciidoc', 'punctuation.definition.asciidoc']

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -1,6 +1,8 @@
 @import 'syntax-variables';
 
 @syntax-text-color-unobtrusive: fadeout(@syntax-text-color, 50%);
+@syntax-text-mark: mix(@syntax-color-constant, @syntax-color-keyword, 50%);
+@syntax-text-highlight: mix(yellow, @syntax-background-color, 70%);
 
 atom-text-editor::shadow, :host {
   .asciidoc {
@@ -15,8 +17,13 @@ atom-text-editor::shadow, :host {
         font-style: italic;
       }
 
+      &.mark {
+        color: @syntax-text-mark;
+      }
+
       &.highlight {
-        color: mix(@syntax-color-constant, @syntax-color-keyword, 50%);
+        color: black;
+        background-color: @syntax-text-highlight;
       }
 
       &.character-reference {

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -15,6 +15,10 @@ atom-text-editor::shadow, :host {
         font-style: italic;
       }
 
+      &.highlight {
+        color: mix(@syntax-color-constant, @syntax-color-keyword, 50%);
+      }
+
       &.character-reference {
         font-style: italic;
         color: mix(red, @syntax-text-color, 20%);


### PR DESCRIPTION
## Description

http://asciidoctor.org/docs/user-manual/#custom-styling-with-attributes

## Syntax example

```adoc
.foobar
[role]**foo** bar
[role]*foo* bar
[role]__foo__ bar
[role]_foo_ bar
[role]##foo## bar
[role role2]#foo# bar
[role]``foo`` bar
[role]`foo` bar
[role]^foo^bar^foo^bar
[role]~foo~bar~foo~bar
```

## Screenshots

![capture du 2016-05-16 21-55-19](https://cloud.githubusercontent.com/assets/5674651/15302012/ea627386-1bb0-11e6-9ea6-cb0ec7f300d0.png)

