### PR TITLE
feat: typographic quotes

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -863,28 +863,28 @@ repository:
   "typographic-quotes":
     patterns: [
       {
-        name: "markup.other.typographic-quotes.asciidoc"
+        name: "markup.quote.typographic-quotes.asciidoc"
         comment: "double-quoted"
         match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"`)(\\S|\\S.*?\\S)(`\")(?!\\p{Word})"
         captures:
           "1":
             name: "markup.meta.attribute-list.asciidoc"
           "3":
-            name: "constant.other.symbol.asciidoc"
+            name: "punctuation.definition.asciidoc"
           "5":
-            name: "constant.other.symbol.asciidoc"
+            name: "punctuation.definition.asciidoc"
       }
       {
-        name: "markup.other.typographic-quotes.asciidoc"
+        name: "markup.quote.typographic-quotes.asciidoc"
         comment: "single-quoted"
         match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?('`)(\\S|\\S.*?\\S)(`')(?!\\p{Word})"
         captures:
           "1":
             name: "markup.meta.attribute-list.asciidoc"
           "3":
-            name: "constant.other.symbol.asciidoc"
+            name: "punctuation.definition.asciidoc"
           "5":
-            name: "constant.other.symbol.asciidoc"
+            name: "punctuation.definition.asciidoc"
       }
     ]
   "xref-macro":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -863,7 +863,7 @@ repository:
   "typographic-quotes":
     patterns: [
       {
-        name: "markup.quote.typographic-quotes.asciidoc"
+        name: "markup.italic.quote.typographic-quotes.asciidoc"
         comment: "double-quoted"
         match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"`)(\\S|\\S.*?\\S)(`\")(?!\\p{Word})"
         captures:
@@ -875,7 +875,7 @@ repository:
             name: "punctuation.definition.asciidoc"
       }
       {
-        name: "markup.quote.typographic-quotes.asciidoc"
+        name: "markup.italic.quote.typographic-quotes.asciidoc"
         comment: "single-quoted"
         match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?('`)(\\S|\\S.*?\\S)(`')(?!\\p{Word})"
         captures:

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -140,6 +140,9 @@ repository:
   inlines:
     patterns: [
       {
+        include: "#typographic-quotes"
+      }
+      {
         include: "#strong"
       }
       {
@@ -855,6 +858,33 @@ repository:
             name: "punctuation.definition.asciidoc"
           "5":
             name: "punctuation.definition.asciidoc"
+      }
+    ]
+  "typographic-quotes":
+    patterns: [
+      {
+        name: "markup.other.typographic-quotes.asciidoc"
+        comment: "double-quoted"
+        match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"`)(\\S|\\S.*?\\S)(`\")(?!\\p{Word})"
+        captures:
+          "1":
+            name: "markup.meta.attribute-list.asciidoc"
+          "3":
+            name: "constant.other.symbol.asciidoc"
+          "5":
+            name: "constant.other.symbol.asciidoc"
+      }
+      {
+        name: "markup.other.typographic-quotes.asciidoc"
+        comment: "single-quoted"
+        match: "(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?('`)(\\S|\\S.*?\\S)(`')(?!\\p{Word})"
+        captures:
+          "1":
+            name: "markup.meta.attribute-list.asciidoc"
+          "3":
+            name: "constant.other.symbol.asciidoc"
+          "5":
+            name: "constant.other.symbol.asciidoc"
       }
     ]
   "xref-macro":

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -93,6 +93,8 @@ repository:
     ]
   inlines:
     patterns: [
+      include: '#typographic-quotes'
+    ,
       include: '#strong'
     ,
       include: '#monospace'

--- a/grammars/repositories/inlines/typographic-quotes-grammar.cson
+++ b/grammars/repositories/inlines/typographic-quotes-grammar.cson
@@ -10,13 +10,13 @@ patterns: [
   #   "`double-quoted`"
   #   [bar]"`double-quoted`"
   #
-  name: 'markup.other.typographic-quotes.asciidoc'
+  name: 'markup.quote.typographic-quotes.asciidoc'
   comment: 'double-quoted'
   match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"\`)(\\S|\\S.*?\\S)(\`\")(?!\\p{Word})'
   captures:
     1: name: 'markup.meta.attribute-list.asciidoc'
-    3: name: 'constant.other.symbol.asciidoc'
-    5: name: 'constant.other.symbol.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
 ,
   # Matches typographic single quotes.
   #
@@ -25,11 +25,11 @@ patterns: [
   #   '`single-quoted`'
   #   [bar]'`single-quoted`'
   #
-  name: 'markup.other.typographic-quotes.asciidoc'
+  name: 'markup.quote.typographic-quotes.asciidoc'
   comment: 'single-quoted'
   match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\'\`)(\\S|\\S.*?\\S)(\`\')(?!\\p{Word})'
   captures:
     1: name: 'markup.meta.attribute-list.asciidoc'
-    3: name: 'constant.other.symbol.asciidoc'
-    5: name: 'constant.other.symbol.asciidoc'
+    3: name: 'punctuation.definition.asciidoc'
+    5: name: 'punctuation.definition.asciidoc'
 ]

--- a/grammars/repositories/inlines/typographic-quotes-grammar.cson
+++ b/grammars/repositories/inlines/typographic-quotes-grammar.cson
@@ -10,7 +10,7 @@ patterns: [
   #   "`double-quoted`"
   #   [bar]"`double-quoted`"
   #
-  name: 'markup.quote.typographic-quotes.asciidoc'
+  name: 'markup.italic.quote.typographic-quotes.asciidoc'
   comment: 'double-quoted'
   match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"\`)(\\S|\\S.*?\\S)(\`\")(?!\\p{Word})'
   captures:
@@ -25,7 +25,7 @@ patterns: [
   #   '`single-quoted`'
   #   [bar]'`single-quoted`'
   #
-  name: 'markup.quote.typographic-quotes.asciidoc'
+  name: 'markup.italic.quote.typographic-quotes.asciidoc'
   comment: 'single-quoted'
   match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\'\`)(\\S|\\S.*?\\S)(\`\')(?!\\p{Word})'
   captures:

--- a/grammars/repositories/inlines/typographic-quotes-grammar.cson
+++ b/grammars/repositories/inlines/typographic-quotes-grammar.cson
@@ -1,0 +1,35 @@
+key: 'typographic-quotes'
+
+# http://asciidoctor.org/docs/user-manual/#curved
+patterns: [
+
+  # Matches typographic double quotes.
+  #
+  # Examples:
+  #
+  #   "`double-quoted`"
+  #   [bar]"`double-quoted`"
+  #
+  name: 'markup.other.typographic-quotes.asciidoc'
+  comment: 'double-quoted'
+  match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\"\`)(\\S|\\S.*?\\S)(\`\")(?!\\p{Word})'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    3: name: 'constant.other.symbol.asciidoc'
+    5: name: 'constant.other.symbol.asciidoc'
+,
+  # Matches typographic single quotes.
+  #
+  # Examples:
+  #
+  #   '`single-quoted`'
+  #   [bar]'`single-quoted`'
+  #
+  name: 'markup.other.typographic-quotes.asciidoc'
+  comment: 'single-quoted'
+  match: '(?:^|(?<!\\p{Word}|;|:))(\\[([^\\]]+?)\\])?(\'\`)(\\S|\\S.*?\\S)(\`\')(?!\\p{Word})'
+  captures:
+    1: name: 'markup.meta.attribute-list.asciidoc'
+    3: name: 'constant.other.symbol.asciidoc'
+    5: name: 'constant.other.symbol.asciidoc'
+]

--- a/spec/inlines/typographic-quotes-grammar-spec.coffee
+++ b/spec/inlines/typographic-quotes-grammar-spec.coffee
@@ -1,0 +1,59 @@
+describe 'typographic quotes', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  # convenience function during development
+  debug = (tokens) ->
+    console.log(JSON.stringify tokens, null, ' ')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes typographic double quotes when', ->
+
+    it 'in a simple phrase', ->
+      {tokens} = grammar.tokenizeLine 'foo "`double-quoted`" foo'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
+
+    it 'has role', ->
+      {tokens} = grammar.tokenizeLine 'foo [bar]"`double-quoted`" foo'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
+
+  describe 'Should tokenizes typographic single quotes when', ->
+
+    it 'in a simple phrase', ->
+      {tokens} = grammar.tokenizeLine 'foo \'`single-quoted`\' foo'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
+
+    it 'has role', ->
+      {tokens} = grammar.tokenizeLine 'foo [bar]\'`single-quoted`\' foo'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']

--- a/spec/inlines/typographic-quotes-grammar-spec.coffee
+++ b/spec/inlines/typographic-quotes-grammar-spec.coffee
@@ -22,19 +22,19 @@ describe 'typographic quotes', ->
       {tokens} = grammar.tokenizeLine 'foo "`double-quoted`" foo'
       expect(tokens).toHaveLength 5
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
-      expect(tokens[3]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
     it 'has role', ->
       {tokens} = grammar.tokenizeLine 'foo [bar]"`double-quoted`" foo'
       expect(tokens).toHaveLength 6
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[2]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
-      expect(tokens[3]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
-      expect(tokens[4]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
   describe 'Should tokenizes typographic single quotes when', ->
@@ -43,17 +43,17 @@ describe 'typographic quotes', ->
       {tokens} = grammar.tokenizeLine 'foo \'`single-quoted`\' foo'
       expect(tokens).toHaveLength 5
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
-      expect(tokens[3]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
     it 'has role', ->
       {tokens} = grammar.tokenizeLine 'foo [bar]\'`single-quoted`\' foo'
       expect(tokens).toHaveLength 6
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[2]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
-      expect(tokens[3]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc']
-      expect(tokens[4]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.other.typographic-quotes.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']

--- a/spec/inlines/typographic-quotes-grammar-spec.coffee
+++ b/spec/inlines/typographic-quotes-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'typographic quotes', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
@@ -22,19 +18,19 @@ describe 'typographic quotes', ->
       {tokens} = grammar.tokenizeLine 'foo "`double-quoted`" foo'
       expect(tokens).toHaveLength 5
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
-      expect(tokens[3]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
     it 'has role', ->
       {tokens} = grammar.tokenizeLine 'foo [bar]"`double-quoted`" foo'
       expect(tokens).toHaveLength 6
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[2]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[3]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
-      expect(tokens[4]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '"`', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'double-quoted', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`"', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
   describe 'Should tokenizes typographic single quotes when', ->
@@ -43,17 +39,17 @@ describe 'typographic quotes', ->
       {tokens} = grammar.tokenizeLine 'foo \'`single-quoted`\' foo'
       expect(tokens).toHaveLength 5
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[2]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
-      expect(tokens[3]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc']
+      expect(tokens[3]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[4]).toEqualJson value: ' foo', scopes: ['source.asciidoc']
 
     it 'has role', ->
       {tokens} = grammar.tokenizeLine 'foo [bar]\'`single-quoted`\' foo'
       expect(tokens).toHaveLength 6
       expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
-      expect(tokens[2]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
-      expect(tokens[3]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc']
-      expect(tokens[4]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[bar]', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '\'`', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'single-quoted', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc']
+      expect(tokens[4]).toEqualJson value: '`\'', scopes: ['source.asciidoc', 'markup.italic.quote.typographic-quotes.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[5]).toEqualJson value: ' foo', scopes: ['source.asciidoc']

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -118,9 +118,5 @@ atom-text-editor::shadow, :host {
       color: @syntax-text-color-unobtrusive;
     }
 
-    .quote {
-      color: mix(blue, @syntax-text-color, 20%);
-    }
-
   }
 }


### PR DESCRIPTION
## Description

Quotation Marks and Apostrophes: http://asciidoctor.org/docs/user-manual/#curved

## Syntax example

```adoc
foo [bar]"`double-quoted`" foo
foo [bar]'`single-quoted`' foo
foo "`double-quoted`" foo
foo '`single-quoted`' foo
```

## Screenshots

![capture du 2016-05-18 21-15-57](https://cloud.githubusercontent.com/assets/5674651/15371860/d8618c4c-1d3d-11e6-8c2c-50ca993a2dcd.png)


