### PR TITLE
feat: inline assignement

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -542,7 +542,22 @@ repository:
     patterns: [
       {
         name: "markup.substitution.attribute-reference.asciidoc"
-        match: "(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})"
+        match: "(?<!\\\\)(\\{)(set|counter2?)(:)([\\p{Alnum}\\-_!]+)((:)(.*?))?(?<!\\\\)(\\})"
+        captures:
+          "2":
+            name: "entity.name.function.asciidoc"
+          "3":
+            name: "punctuation.separator.asciidoc"
+          "4":
+            name: "support.constant.attribute-name.asciidoc"
+          "6":
+            name: "punctuation.separator.asciidoc"
+          "7":
+            name: "string.unquoted.attribute-value.asciidoc"
+      }
+      {
+        name: "markup.substitution.attribute-reference.asciidoc"
+        match: "(?<!\\\\)(\\{)(\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})"
       }
     ]
   "bibliography-anchor":

--- a/grammars/repositories/inlines/attribute-reference-grammar.cson
+++ b/grammars/repositories/inlines/attribute-reference-grammar.cson
@@ -2,16 +2,31 @@ key: 'attribute-reference'
 
 patterns: [
 
+  # Matches document variables inline assignment.
+  #
+  # Examples
+  #
+  #   {counter:pcount:1}
+  #   {counter2:pcount:1}
+  #   {set:foo:bar}
+  #   {set:name!}
+  #
+  name: 'markup.substitution.attribute-reference.asciidoc'
+  match: '(?<!\\\\)(\\{)(set|counter2?)(:)([\\p{Alnum}\\-_!]+)((:)(.*?))?(?<!\\\\)(\\})'
+  captures:
+    2: name: 'entity.name.function.asciidoc'
+    3: name: 'punctuation.separator.asciidoc'
+    4: name: 'support.constant.attribute-name.asciidoc'
+    6: name: 'punctuation.separator.asciidoc'
+    7: name: 'string.unquoted.attribute-value.asciidoc'
+,
   # Matches an inline attribute reference.
   #
   # Examples
   #
   #   {foo}
-  #   {counter:pcount:1}
-  #   {set:foo:bar}
-  #   {set:name!}
+  #   {foo-bar}
   #
   name: 'markup.substitution.attribute-reference.asciidoc'
-  match: '(?<!\\\\)(\\{)((set|counter2?):.+?|\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})'
-
+  match: '(?<!\\\\)(\\{)(\\w+(?:[\\-]\\w+)*)(?<!\\\\)(\\})'
 ]

--- a/spec/inlines/attribute-reference-grammar-spec.coffee
+++ b/spec/inlines/attribute-reference-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes inline attribute-reference when', ->
+describe 'Inline attribute-reference', ->
   grammar = null
 
   beforeEach ->
@@ -8,36 +8,50 @@ describe 'Should tokenizes inline attribute-reference when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'is in a phrase', ->
-    {tokens} = grammar.tokenizeLine 'foobar {mylink} foobar'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '{mylink}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
-    expect(tokens[2]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'is a simple `counter`', ->
-    {tokens} = grammar.tokenizeLine 'foobar {counter:pcount:1} foobar'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '{counter:pcount:1}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
-    expect(tokens[2]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+    it 'is in a phrase', ->
+      {tokens} = grammar.tokenizeLine 'foobar {mylink} foobar'
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '{mylink}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[2]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
 
-  it 'is a simple `set`', ->
-    {tokens} = grammar.tokenizeLine 'foobar {set:foo:bar} foobar'
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '{set:foo:bar}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
-    expect(tokens[2]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+    it 'is an attribute definition `counter`', ->
+      {tokens} = grammar.tokenizeLine 'foobar {counter:pcount:1} foobar'
+      expect(tokens).toHaveLength 9
+      partIndex = 0
+      expect(tokens[partIndex++]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: '{', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: 'counter', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: 'pcount', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: '1', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: '}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+      expect(partIndex).toBe 9
 
-  describe 'Should not tokenizes inline attribute-reference when', ->
+    it 'is a an attribute definition `set`', ->
+      {tokens} = grammar.tokenizeLine 'foobar {set:foo:bar} foobar'
+      expect(tokens).toHaveLength 9
+      partIndex = 0
+      expect(tokens[partIndex++]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: '{', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: 'set', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: 'foo', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'support.constant.attribute-name.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: 'bar', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc', 'string.unquoted.attribute-value.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: '}', scopes: ['source.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[partIndex++]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+      expect(partIndex).toBe 9
+
+  describe 'Should not tokenizes when', ->
 
     it '"{" escaped', ->
       {tokens} = grammar.tokenizeLine 'foobar \\\\{mylink} foobar'


### PR DESCRIPTION
## Description

Highlighting inline attribute definition like others attribute definitions.

## Syntax example

```adoc
{set:attrname!:value}

{counter:pcount:1}
{counter2:pcount:1}

{set:foo:bar}
{set:name!}
```

## Screenshots

![capture du 2016-05-21 11-55-54](https://cloud.githubusercontent.com/assets/5674651/15447704/fcab6528-1f4a-11e6-861d-b6931fac2fe9.png)


