### PR TITLE
refactor: enhance block attribute matching

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -290,7 +290,7 @@ repository:
       }
       {
         comment: "blockname"
-        match: "(?<=\\[)([^\\[\\],.#%]+)"
+        match: "(?<=\\[)([^\\[\\],.#%=]+)"
         captures:
           "0":
             name: "markup.meta.attribute-list.asciidoc"
@@ -1035,10 +1035,10 @@ repository:
     patterns: [
       {
         name: "markup.admonition.asciidoc"
-        begin: "(?=(?>(?:^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#)[^\\]]+)*\\]$)))"
+        begin: "(?=(?>(?:^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#|\\.|%)[^\\]]+)*\\]$)))"
         patterns: [
           {
-            match: "^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#)([^,\\]]+))*\\]$"
+            match: "^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#|\\.|%)([^,\\]]+))*\\]$"
             captures:
               "0":
                 patterns: [
@@ -1142,10 +1142,10 @@ repository:
     patterns: [
       {
         name: "markup.block.passthrough.asciidoc"
-        begin: "(?=(?>(?:^\\[(pass)((?:,|#)[^\\]]+)*\\]$)))"
+        begin: "(?=(?>(?:^\\[(pass)((?:,|#|\\.|%)[^\\]]+)*\\]$)))"
         patterns: [
           {
-            match: "^\\[(pass)((?:,|#)([^,\\]]+))*\\]$"
+            match: "^\\[(pass)((?:,|#|\\.|%)([^,\\]]+))*\\]$"
             captures:
               "0":
                 name: "markup.heading.asciidoc"
@@ -1196,10 +1196,10 @@ repository:
     patterns: [
       {
         name: "markup.italic.quotes.asciidoc"
-        begin: "(?=(?>(?:^\\[(quote|verse)((?:,|#)([^,\\]]+))*\\]$)))"
+        begin: "(?=(?>(?:^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$)))"
         patterns: [
           {
-            match: "^\\[(quote|verse)((?:,|#)([^,\\]]+))*\\]$"
+            match: "^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$"
             captures:
               "0":
                 patterns: [

--- a/grammars/repositories/blocks/admonition-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/admonition-paragraph-grammar.cson
@@ -26,9 +26,9 @@ patterns: [
   #   --
   #
   name: 'markup.admonition.asciidoc'
-  begin: '(?=(?>(?:^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#)[^\\]]+)*\\]$)))'
+  begin: '(?=(?>(?:^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#|\\.|%)[^\\]]+)*\\]$)))'
   patterns: [
-    match: '^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#)([^,\\]]+))*\\]$'
+    match: '^\\[(NOTE|TIP|IMPORTANT|WARNING|CAUTION)((?:,|#|\\.|%)([^,\\]]+))*\\]$'
     captures:
       0:
         patterns: [

--- a/grammars/repositories/blocks/passthrough-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/passthrough-paragraph-grammar.cson
@@ -26,9 +26,9 @@ patterns: [
   #   ++++
   #
   name: 'markup.block.passthrough.asciidoc'
-  begin: '(?=(?>(?:^\\[(pass)((?:,|#)[^\\]]+)*\\]$)))'
+  begin: '(?=(?>(?:^\\[(pass)((?:,|#|\\.|%)[^\\]]+)*\\]$)))'
   patterns: [
-    match: '^\\[(pass)((?:,|#)([^,\\]]+))*\\]$'
+    match: '^\\[(pass)((?:,|#|\\.|%)([^,\\]]+))*\\]$'
     captures:
       0:
         name: 'markup.heading.asciidoc'

--- a/grammars/repositories/blocks/quote-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/quote-paragraph-grammar.cson
@@ -32,9 +32,9 @@ patterns: [
   #   --
   #
   name: 'markup.italic.quotes.asciidoc'
-  begin: '(?=(?>(?:^\\[(quote|verse)((?:,|#)([^,\\]]+))*\\]$)))'
+  begin: '(?=(?>(?:^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$)))'
   patterns: [
-    match: '^\\[(quote|verse)((?:,|#)([^,\\]]+))*\\]$'
+    match: '^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$'
     captures:
       0:
         patterns: [

--- a/grammars/repositories/partials/block-attribute-inner-grammar.cson
+++ b/grammars/repositories/partials/block-attribute-inner-grammar.cson
@@ -9,7 +9,7 @@ patterns: [
   match: '([,.#%])'
 ,
   comment: 'blockname'
-  match: '(?<=\\[)([^\\[\\],.#%]+)'
+  match: '(?<=\\[)([^\\[\\],.#%=]+)'
   captures:
     0:
       name: 'markup.meta.attribute-list.asciidoc'

--- a/spec/blocks/quote-paragraph-grammar-spec.coffee
+++ b/spec/blocks/quote-paragraph-grammar-spec.coffee
@@ -37,6 +37,29 @@ describe 'Quotes paragraph', ->
       expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']
 
+  it 'block attribute defined with some special characters', ->
+    tokens = grammar.tokenizeLines '''
+      [quote%option#id]
+      I don't like it, and I'm sorry I ever had anything to do with it.
+
+      foobar
+      '''
+    expect(tokens).toHaveLength 4
+    expect(tokens[0]).toHaveLength 7
+    expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[0][1]).toEqualJson value: 'quote', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[0][3]).toEqualJson value: 'option', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+    expect(tokens[0][2]).toEqualJson value: '%', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[0][4]).toEqualJson value: '#', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[0][5]).toEqualJson value: 'id', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc', 'markup.meta.attribute-list.asciidoc']
+    expect(tokens[0][6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[1]).toHaveLength 1
+    expect(tokens[1][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
+    expect(tokens[2]).toHaveLength 1
+    expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc']
+    expect(tokens[3]).toHaveLength 1
+    expect(tokens[3][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']
+
   describe 'Should not tokenizes when', ->
 
     it 'beginning with space', ->


### PR DESCRIPTION
## Description

Support `%` and `.` for:
- quotes
- admonition
- pass-through

## Syntax example

```adoc

[quote#someone-quote]
This is just a quote from someone.

[quote.famous]
This is just a quote from someone.

[quote#someone-quote.famous]
This is just a quote from someone.

[quote#id]
This is just a quote from someone.

[quote.role]
This is just a quote from someone.

[quote%option]
This is just a quote from someone.

[quote.role#id]
This is just a quote from someone.

[quote#id.role]
This is just a quote from someone.

[quote%option#id]
This is just a quote from someone.

[quote.role%option]
This is just a quote from someone.
```

## Screenshots

![capture du 2016-05-21 23-45-51](https://cloud.githubusercontent.com/assets/5674651/15450976/2c7de9de-1fae-11e6-816c-5e783d0d94c0.png)


