### PR TITLE
feat: url and attribute reference within list definition

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -460,6 +460,15 @@ repository:
         name: "markup.heading.list.asciidoc"
         match: "^\\p{Blank}*(.*?\\S)(:{2,4}|;;)($|\\p{Blank}+)"
         captures:
+          "1":
+            patterns: [
+              {
+                include: "#link-macro"
+              }
+              {
+                include: "#attribute-reference"
+              }
+            ]
           "2":
             name: "markup.list.bullet.asciidoc"
       }

--- a/grammars/repositories/partials/list-grammar.cson
+++ b/grammars/repositories/partials/list-grammar.cson
@@ -58,5 +58,11 @@ patterns: [
   name: 'markup.heading.list.asciidoc'
   match: '^\\p{Blank}*(.*?\\S)(:{2,4}|;;)($|\\p{Blank}+)'
   captures:
+    1:
+      patterns: [
+        include: '#link-macro'
+      ,
+        include: '#attribute-reference'
+      ]
     2: name: 'markup.list.bullet.asciidoc'
 ]

--- a/spec/partials/list-labeled-grammar-spec.coffee
+++ b/spec/partials/list-labeled-grammar-spec.coffee
@@ -70,6 +70,19 @@ describe 'Labeled list', ->
       expect(tokens[2]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc']
       expect(tokens[3]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']
 
+    it 'contains attribute reference and url', ->
+      {tokens} = grammar.tokenizeLine '{uri-asciidoctorjs-npm}[asciidoctor.js]:: the main npm package for Asciidoctor.js'
+      expect(tokens).toHaveLength 7
+      tokenIndex = 0
+      expect(tokens[tokenIndex++]).toEqualJson value: '{uri-asciidoctorjs-npm}', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc', 'markup.other.url.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: 'asciidoctor.js', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc', 'markup.other.url.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc', 'markup.other.url.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc', 'markup.list.bullet.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.heading.list.asciidoc']
+      expect(tokens[tokenIndex++]).toEqualJson value: 'the main npm package for Asciidoctor.js', scopes: ['source.asciidoc']
+      expect(tokenIndex).toBe 7
+
   describe 'Should not tokenize when', ->
 
     it 'title ending with space', ->


### PR DESCRIPTION
## Description

url and attribute reference within list definition.

## Syntax example

```adoc
{uri-asciidoctorjs-npm}[asciidoctor.js]:: the main npm package for Asciidoctor.js
{uri-grunt-asciidoctor-npm}[grunt-asciidoctor]:: an npm package for processing AsciiDoc source files in your {uri-gruntjs}[Grunt] project

{foo_term}:: {foo_def}
```

## Screenshots

![capture du 2016-05-22 17-45-33](https://cloud.githubusercontent.com/assets/5674651/15454901/0734dbc8-2045-11e6-9fcf-44dc9bc539ee.png)

Your screenshot.

