### PR TITLE
chore: skip AppVeyor on publishing commits

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -268,7 +268,7 @@ We use https://travis-ci.org[Travis CI] to publish this package.
 
 Every merged PR is released as a new version (by default a `patch`).
 
-We use the [Travis CI UI](https://travis-ci.org/asciidoctor/atom-language-asciidoc/settings) to manage the publishing system via secure environment variables:
+We use the https://travis-ci.org/asciidoctor/atom-language-asciidoc/settings[Travis CI UI] to manage the publishing system via secure environment variables:
 
 * `PUBLISH_TYPE`: default `patch`, can be change to `minor`, `major`.
 * `STOP_PUBLISH`: if defined, prevent the publishing.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,27 @@
 version: '{build}'
+
 skip_tags: true
-# NOTE: AppVeyor automatically skips the build if the commit contains [ci skip] or [skip ci]
+
+# NOTE: AppVeyor automatically skips the build if the commit contains [ci skip] or [skip ci] or [skip appveyor]
+skip_commits:
+  author: asciidoctor-docbot
+
 clone_depth: 10
+
 platform: x64
+
 environment:
   APM_TEST_PACKAGES:
   matrix:
     - ATOM_CHANNEL: stable
     - ATOM_CHANNEL: beta
+
 install:
   - ps: Install-Product node 5
+
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
 test: off
+
 deploy: off


### PR DESCRIPTION
Skip AppVeyor builds when asciidoctor-docbot commit.

