### PR TITLE
feat: source and literal delimiter

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -393,7 +393,7 @@ repository:
   "include-directive":
     patterns: [
       {
-        match: "\\b(include)(::)([^\\[]+)(\\[)(.*?)(\\])$"
+        match: "^(include)(::)([^\\[]+)(\\[)(.*?)(\\])$"
         captures:
           "1":
             name: "entity.name.function.asciidoc"

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -317,7 +317,7 @@ repository:
     patterns: [
       {
         name: "callout.source.code.asciidoc"
-        match: "(?:(?:\\/\\/|#|--|;;) ?)?(\\\\)?(<)!?(--|)(\\d+)\\3(>)(?=(?: ?\\\\?<!?\\3\\d+\\3>)*$)"
+        match: "(?:(?:\\/\\/|#|--|;;) ?)?( )?(?<!\\\\)(<)!?(--|)(\\d+)\\3(>)(?=(?: ?<!?\\3\\d+\\3>)*$)"
         captures:
           "2":
             name: "constant.other.symbol.asciidoc"

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -720,30 +720,30 @@ repository:
     patterns: [
       {
         name: "markup.macro.block.general.asciidoc"
-        match: "^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)\\]$"
+        match: "^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])$"
         captures:
           "1":
             name: "entity.name.function.asciidoc"
           "2":
             name: "punctuation.separator.asciidoc"
           "3":
-            "4":
-              name: "punctuation.separator.asciidoc"
-            "5":
-              name: "string.unquoted.asciidoc"
-              patterns: [
-                {
-                  include: "#attribute-reference"
-                }
-              ]
-            "6":
-              name: "punctuation.separator.asciidoc"
             name: "markup.link.asciidoc"
             patterns: [
               {
                 include: "#attribute-reference"
               }
             ]
+          "4":
+            name: "punctuation.separator.asciidoc"
+          "5":
+            name: "string.unquoted.asciidoc"
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
+          "6":
+            name: "punctuation.separator.asciidoc"
       }
     ]
   "image-macro":

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -390,6 +390,35 @@ repository:
         match: "^(?:'|<){3,}$|^ {0,3}([-\\*'])( *)\\1\\2\\1$"
       }
     ]
+  "include-directive":
+    patterns: [
+      {
+        match: "\\b(include)(::)([^\\[]+)(\\[)(.*?)(\\])$"
+        captures:
+          "1":
+            name: "entity.name.function.asciidoc"
+          "2":
+            name: "punctuation.separator.asciidoc"
+          "3":
+            name: "markup.link.asciidoc"
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
+          "4":
+            name: "punctuation.separator.asciidoc"
+          "5":
+            name: "string.unquoted.asciidoc"
+            patterns: [
+              {
+                include: "#attribute-reference"
+              }
+            ]
+          "6":
+            name: "punctuation.separator.asciidoc"
+      }
+    ]
   keywords:
     patterns: [
       {
@@ -691,14 +720,25 @@ repository:
     patterns: [
       {
         name: "markup.macro.block.general.asciidoc"
-        match: "^(\\p{Word}+)::(\\S*?)\\[((?:\\\\\\]|[^\\]])*?)\\]$"
+        match: "^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)\\]$"
         captures:
           "1":
             name: "entity.name.function.asciidoc"
           "2":
-            name: "markup.link.asciidoc"
+            name: "punctuation.separator.asciidoc"
           "3":
-            name: "string.unquoted.asciidoc"
+            "4":
+              name: "punctuation.separator.asciidoc"
+            "5":
+              name: "string.unquoted.asciidoc"
+              patterns: [
+                {
+                  include: "#attribute-reference"
+                }
+              ]
+            "6":
+              name: "punctuation.separator.asciidoc"
+            name: "markup.link.asciidoc"
             patterns: [
               {
                 include: "#attribute-reference"
@@ -1452,6 +1492,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.c"
               }
             ]
@@ -1466,6 +1509,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.c"
               }
             ]
@@ -1478,6 +1524,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.c"
@@ -1518,6 +1567,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.clojure"
               }
             ]
@@ -1532,6 +1584,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.clojure"
               }
             ]
@@ -1544,6 +1599,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.clojure"
@@ -1584,6 +1642,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.coffee"
               }
             ]
@@ -1598,6 +1659,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.coffee"
               }
             ]
@@ -1610,6 +1674,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.coffee"
@@ -1650,6 +1717,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.cpp"
               }
             ]
@@ -1664,6 +1734,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.cpp"
               }
             ]
@@ -1676,6 +1749,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.cpp"
@@ -1716,6 +1792,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css"
               }
             ]
@@ -1730,6 +1809,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css"
               }
             ]
@@ -1742,6 +1824,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.css"
@@ -1782,6 +1867,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.cs"
               }
             ]
@@ -1796,6 +1884,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.cs"
               }
             ]
@@ -1808,6 +1899,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.cs"
@@ -1848,6 +1942,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.diff"
               }
             ]
@@ -1862,6 +1959,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.diff"
               }
             ]
@@ -1874,6 +1974,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.diff"
@@ -1914,6 +2017,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.dockerfile"
               }
             ]
@@ -1928,6 +2034,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.dockerfile"
               }
             ]
@@ -1940,6 +2049,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.dockerfile"
@@ -1980,6 +2092,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.elixir"
               }
             ]
@@ -1994,6 +2109,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.elixir"
               }
             ]
@@ -2006,6 +2124,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.elixir"
@@ -2046,6 +2167,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.elm"
               }
             ]
@@ -2060,6 +2184,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.elm"
               }
             ]
@@ -2072,6 +2199,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.elm"
@@ -2112,6 +2242,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.erlang"
               }
             ]
@@ -2126,6 +2259,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.erlang"
               }
             ]
@@ -2138,6 +2274,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.erlang"
@@ -2178,6 +2317,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.go"
               }
             ]
@@ -2192,6 +2334,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.go"
               }
             ]
@@ -2204,6 +2349,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.go"
@@ -2244,6 +2392,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.groovy"
               }
             ]
@@ -2258,6 +2409,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.groovy"
               }
             ]
@@ -2270,6 +2424,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.groovy"
@@ -2310,6 +2467,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.haskell"
               }
             ]
@@ -2324,6 +2484,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.haskell"
               }
             ]
@@ -2336,6 +2499,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.haskell"
@@ -2376,6 +2542,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.basic"
               }
             ]
@@ -2390,6 +2559,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.basic"
               }
             ]
@@ -2402,6 +2574,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "text.html.basic"
@@ -2442,6 +2617,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.java"
               }
             ]
@@ -2456,6 +2634,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.java"
               }
             ]
@@ -2468,6 +2649,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.java"
@@ -2508,6 +2692,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.js"
               }
             ]
@@ -2522,6 +2709,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.js"
               }
             ]
@@ -2534,6 +2724,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.js"
@@ -2574,6 +2767,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.json"
               }
             ]
@@ -2588,6 +2784,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.json"
               }
             ]
@@ -2600,6 +2799,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.json"
@@ -2640,6 +2842,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.js.jsx"
               }
             ]
@@ -2654,6 +2859,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.js.jsx"
               }
             ]
@@ -2666,6 +2874,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.js.jsx"
@@ -2706,6 +2917,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.julia"
               }
             ]
@@ -2720,6 +2934,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.julia"
               }
             ]
@@ -2732,6 +2949,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.julia"
@@ -2772,6 +2992,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css.less"
               }
             ]
@@ -2786,6 +3009,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css.less"
               }
             ]
@@ -2798,6 +3024,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.css.less"
@@ -2838,6 +3067,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.makefile"
               }
             ]
@@ -2852,6 +3084,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.makefile"
               }
             ]
@@ -2864,6 +3099,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.makefile"
@@ -2904,6 +3142,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.gfm"
               }
             ]
@@ -2918,6 +3159,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.gfm"
               }
             ]
@@ -2930,6 +3174,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.gfm"
@@ -2970,6 +3217,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.mustache"
               }
             ]
@@ -2984,6 +3234,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.mustache"
               }
             ]
@@ -2996,6 +3249,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "text.html.mustache"
@@ -3036,6 +3292,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.objc"
               }
             ]
@@ -3050,6 +3309,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.objc"
               }
             ]
@@ -3062,6 +3324,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.objc"
@@ -3102,6 +3367,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ocaml"
               }
             ]
@@ -3116,6 +3384,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ocaml"
               }
             ]
@@ -3128,6 +3399,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.ocaml"
@@ -3168,6 +3442,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.perl"
               }
             ]
@@ -3182,6 +3459,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.perl"
               }
             ]
@@ -3194,6 +3474,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.perl"
@@ -3234,6 +3517,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.perl6"
               }
             ]
@@ -3248,6 +3534,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.perl6"
               }
             ]
@@ -3260,6 +3549,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.perl6"
@@ -3300,6 +3592,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.php"
               }
             ]
@@ -3314,6 +3609,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.html.php"
               }
             ]
@@ -3326,6 +3624,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "text.html.php"
@@ -3366,6 +3667,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.asciidoc.properties"
               }
             ]
@@ -3380,6 +3684,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.asciidoc.properties"
               }
             ]
@@ -3392,6 +3699,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.asciidoc.properties"
@@ -3432,6 +3742,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.python"
               }
             ]
@@ -3446,6 +3759,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.python"
               }
             ]
@@ -3458,6 +3774,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.python"
@@ -3498,6 +3817,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.r"
               }
             ]
@@ -3512,6 +3834,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.r"
               }
             ]
@@ -3524,6 +3849,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.r"
@@ -3564,6 +3892,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ruby"
               }
             ]
@@ -3578,6 +3909,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ruby"
               }
             ]
@@ -3590,6 +3924,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.ruby"
@@ -3630,6 +3967,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.rust"
               }
             ]
@@ -3644,6 +3984,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.rust"
               }
             ]
@@ -3656,6 +3999,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.rust"
@@ -3696,6 +4042,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.sass"
               }
             ]
@@ -3710,6 +4059,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.sass"
               }
             ]
@@ -3722,6 +4074,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.sass"
@@ -3762,6 +4117,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.scala"
               }
             ]
@@ -3776,6 +4134,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.scala"
               }
             ]
@@ -3788,6 +4149,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.scala"
@@ -3828,6 +4192,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css.scss"
               }
             ]
@@ -3842,6 +4209,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.css.scss"
               }
             ]
@@ -3854,6 +4224,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.css.scss"
@@ -3894,6 +4267,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.shell"
               }
             ]
@@ -3908,6 +4284,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.shell"
               }
             ]
@@ -3920,6 +4299,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.shell"
@@ -3960,6 +4342,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.sql"
               }
             ]
@@ -3974,6 +4359,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.sql"
               }
             ]
@@ -3986,6 +4374,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.sql"
@@ -4026,6 +4417,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.swift"
               }
             ]
@@ -4040,6 +4434,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.swift"
               }
             ]
@@ -4052,6 +4449,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.swift"
@@ -4092,6 +4492,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.toml"
               }
             ]
@@ -4106,6 +4509,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.toml"
               }
             ]
@@ -4118,6 +4524,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.toml"
@@ -4158,6 +4567,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ts"
               }
             ]
@@ -4172,6 +4584,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.ts"
               }
             ]
@@ -4184,6 +4599,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.ts"
@@ -4224,6 +4642,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.xml"
               }
             ]
@@ -4238,6 +4659,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "text.xml"
               }
             ]
@@ -4250,6 +4674,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "text.xml"
@@ -4290,6 +4717,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.yaml"
               }
             ]
@@ -4304,6 +4734,9 @@ repository:
                 include: "#block-callout"
               }
               {
+                include: "#include-directive"
+              }
+              {
                 include: "source.yaml"
               }
             ]
@@ -4316,6 +4749,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
               {
                 include: "source.yaml"
@@ -4354,6 +4790,9 @@ repository:
               {
                 include: "#block-callout"
               }
+              {
+                include: "#include-directive"
+              }
             ]
             end: "(?<=\\1)"
           }
@@ -4365,6 +4804,9 @@ repository:
               {
                 include: "#block-callout"
               }
+              {
+                include: "#include-directive"
+              }
             ]
             end: "^(\\1)$"
           }
@@ -4375,6 +4817,9 @@ repository:
             patterns: [
               {
                 include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
               }
             ]
             end: "^(\\1)$"
@@ -4391,6 +4836,9 @@ repository:
         patterns: [
           {
             include: "#block-callout"
+          }
+          {
+            include: "#include-directive"
           }
         ]
         end: "^(\\1)$"

--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -1471,8 +1471,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.c"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.c"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.clojure.asciidoc"
@@ -1523,8 +1537,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.clojure"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.clojure"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.coffee.asciidoc"
@@ -1575,8 +1603,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.coffee"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.coffee"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.cpp.asciidoc"
@@ -1627,8 +1669,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.cpp"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.cpp"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.asciidoc"
@@ -1679,8 +1735,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.css"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.css"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.cs.asciidoc"
@@ -1731,8 +1801,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.cs"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.cs"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.diff.asciidoc"
@@ -1783,8 +1867,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.diff"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.diff"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.dockerfile.asciidoc"
@@ -1835,8 +1933,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.dockerfile"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.dockerfile"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.elixir.asciidoc"
@@ -1887,8 +1999,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.elixir"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.elixir"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.elm.asciidoc"
@@ -1939,8 +2065,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.elm"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.elm"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.erlang.asciidoc"
@@ -1991,8 +2131,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.erlang"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.erlang"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.go.asciidoc"
@@ -2043,8 +2197,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.go"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.go"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.groovy.asciidoc"
@@ -2095,8 +2263,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.groovy"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.groovy"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.haskell.asciidoc"
@@ -2147,8 +2329,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.haskell"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.haskell"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.basic.asciidoc"
@@ -2199,8 +2395,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "text.embedded.html.basic"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "text.html.basic"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.java.asciidoc"
@@ -2251,8 +2461,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.java"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.java"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.js.asciidoc"
@@ -2303,8 +2527,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.js"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.js"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.json.asciidoc"
@@ -2355,8 +2593,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.json"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.json"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.js.jsx.asciidoc"
@@ -2407,8 +2659,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.js.jsx"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.js.jsx"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.julia.asciidoc"
@@ -2459,8 +2725,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.julia"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.julia"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.less.asciidoc"
@@ -2511,8 +2791,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.css.less"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.css.less"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.makefile.asciidoc"
@@ -2563,8 +2857,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.makefile"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.makefile"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.gfm.asciidoc"
@@ -2615,8 +2923,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.gfm"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.gfm"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.mustache.asciidoc"
@@ -2667,8 +2989,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "text.embedded.html.mustache"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "text.html.mustache"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.objc.asciidoc"
@@ -2719,8 +3055,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.objc"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.objc"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ocaml.asciidoc"
@@ -2771,8 +3121,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.ocaml"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.ocaml"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.perl.asciidoc"
@@ -2823,8 +3187,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.perl"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.perl"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.perl6.asciidoc"
@@ -2875,8 +3253,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.perl6"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.perl6"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.php.asciidoc"
@@ -2927,8 +3319,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "text.embedded.html.php"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "text.html.php"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.asciidoc.properties.asciidoc"
@@ -2979,8 +3385,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.asciidoc.properties"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.asciidoc.properties"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.python.asciidoc"
@@ -3031,8 +3451,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.python"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.python"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.r.asciidoc"
@@ -3083,8 +3517,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.r"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.r"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ruby.asciidoc"
@@ -3135,8 +3583,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.ruby"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.ruby"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.rust.asciidoc"
@@ -3187,8 +3649,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.rust"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.rust"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.sass.asciidoc"
@@ -3239,8 +3715,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.sass"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.sass"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.scala.asciidoc"
@@ -3291,8 +3781,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.scala"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.scala"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.scss.asciidoc"
@@ -3343,8 +3847,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.css.scss"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.css.scss"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.shell.asciidoc"
@@ -3395,8 +3913,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.shell"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.shell"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.sql.asciidoc"
@@ -3447,8 +3979,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.sql"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.sql"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.swift.asciidoc"
@@ -3499,8 +4045,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.swift"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.swift"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.toml.asciidoc"
@@ -3551,8 +4111,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.toml"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.toml"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ts.asciidoc"
@@ -3603,8 +4177,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.ts"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.ts"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.xml.asciidoc"
@@ -3655,8 +4243,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "text.embedded.xml"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "text.xml"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.yaml.asciidoc"
@@ -3707,8 +4309,22 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.yaml"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "source.yaml"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         begin: "(?=(?>(?:^\\[(source)((?:,|#)[^\\]]+)*\\]$)))"
@@ -3752,8 +4368,19 @@ repository:
             ]
             end: "^(\\1)$"
           }
+          {
+            comment: "literal block"
+            name: "markup.raw.asciidoc"
+            begin: "^(\\.{4})\\s*$"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+            ]
+            end: "^(\\1)$"
+          }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
         name: "markup.raw.asciidoc"

--- a/grammars/repositories/inlines/general-block-macro-grammar.cson
+++ b/grammars/repositories/inlines/general-block-macro-grammar.cson
@@ -9,20 +9,20 @@ patterns: [
  #   gist::123456[]
  #
  name: 'markup.macro.block.general.asciidoc'
- match: '^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)\\]$'
+ match: '^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])$'
  captures:
-   1: name: 'entity.name.function.asciidoc'
-   2: name: 'punctuation.separator.asciidoc'
-   3:
+  1: name: 'entity.name.function.asciidoc'
+  2: name: 'punctuation.separator.asciidoc'
+  3:
     name: 'markup.link.asciidoc'
     patterns: [
       include: '#attribute-reference'
     ]
-    4: name: 'punctuation.separator.asciidoc'
-    5:
-      name: 'string.unquoted.asciidoc'
-      patterns: [
-        include: '#attribute-reference'
-      ]
-    6: name: 'punctuation.separator.asciidoc'
+  4: name: 'punctuation.separator.asciidoc'
+  5:
+    name: 'string.unquoted.asciidoc'
+    patterns: [
+      include: '#attribute-reference'
+    ]
+  6: name: 'punctuation.separator.asciidoc'
 ]

--- a/grammars/repositories/inlines/general-block-macro-grammar.cson
+++ b/grammars/repositories/inlines/general-block-macro-grammar.cson
@@ -9,13 +9,20 @@ patterns: [
  #   gist::123456[]
  #
  name: 'markup.macro.block.general.asciidoc'
- match: '^(\\p{Word}+)::(\\S*?)\\[((?:\\\\\\]|[^\\]])*?)\\]$'
+ match: '^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)\\]$'
  captures:
    1: name: 'entity.name.function.asciidoc'
-   2: name: 'markup.link.asciidoc'
+   2: name: 'punctuation.separator.asciidoc'
    3:
-    name: 'string.unquoted.asciidoc'
+    name: 'markup.link.asciidoc'
     patterns: [
       include: '#attribute-reference'
     ]
+    4: name: 'punctuation.separator.asciidoc'
+    5:
+      name: 'string.unquoted.asciidoc'
+      patterns: [
+        include: '#attribute-reference'
+      ]
+    6: name: 'punctuation.separator.asciidoc'
 ]

--- a/grammars/repositories/partials/block-callout-grammar.cson
+++ b/grammars/repositories/partials/block-callout-grammar.cson
@@ -10,7 +10,7 @@ patterns: [
     #   <!--1--> (for XML-based languages)
     #
     name: 'callout.source.code.asciidoc'
-    match: '(?:(?:\\/\\/|#|--|;;) ?)?(\\\\)?(<)!?(--|)(\\d+)\\3(>)(?=(?: ?\\\\?<!?\\3\\d+\\3>)*$)'
+    match: '(?:(?:\\/\\/|#|--|;;) ?)?( )?(?<!\\\\)(<)!?(--|)(\\d+)\\3(>)(?=(?: ?<!?\\3\\d+\\3>)*$)'
     captures:
       2: name: 'constant.other.symbol.asciidoc'
       4: name: 'constant.numeric.asciidoc'

--- a/grammars/repositories/partials/include-directive-grammar.cson
+++ b/grammars/repositories/partials/include-directive-grammar.cson
@@ -8,7 +8,7 @@ key: 'include-directive'
 #   include::{testpkg}/WhenAttributesAreUsed.java[tags=uri-scheme]
 #
 patterns: [
-  match: '\\b(include)(::)([^\\[]+)(\\[)(.*?)(\\])$'
+  match: '^(include)(::)([^\\[]+)(\\[)(.*?)(\\])$'
   captures:
     1: name: 'entity.name.function.asciidoc'
     2: name: 'punctuation.separator.asciidoc'

--- a/grammars/repositories/partials/include-directive-grammar.cson
+++ b/grammars/repositories/partials/include-directive-grammar.cson
@@ -1,0 +1,27 @@
+key: 'include-directive'
+
+# Matches the include directive.
+# http://asciidoctor.org/docs/user-manual/#include-directive
+#
+# Examples
+#
+#   include::{testpkg}/WhenAttributesAreUsed.java[tags=uri-scheme]
+#
+patterns: [
+  match: '\\b(include)(::)([^\\[]+)(\\[)(.*?)(\\])$'
+  captures:
+    1: name: 'entity.name.function.asciidoc'
+    2: name: 'punctuation.separator.asciidoc'
+    3:
+      name: 'markup.link.asciidoc'
+      patterns: [
+        include: '#attribute-reference'
+      ]
+    4: name: 'punctuation.separator.asciidoc'
+    5:
+     name: 'string.unquoted.asciidoc'
+     patterns: [
+       include: '#attribute-reference'
+     ]
+    6: name: 'punctuation.separator.asciidoc'
+]

--- a/lib/code-block-generator.coffee
+++ b/lib/code-block-generator.coffee
@@ -38,8 +38,18 @@ module.exports =
           include: "#{lang.type}.#{lang.code}"
         ]
         end: '^(\\1)$'
+      ,
+        comment: 'literal block'
+        begin: '^(\\.{4})\\s*$'
+        contentName: "#{lang.type}.embedded.#{lang.code}"
+        patterns: [
+          include: '#block-callout'
+        ,
+          include: "#{lang.type}.#{lang.code}"
+        ]
+        end: '^(\\1)$'
       ]
-      end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+      end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
 
     # add generic block
     codeBlocks.push
@@ -72,8 +82,16 @@ module.exports =
           include: '#block-callout'
         ]
         end: '^(\\1)$'
+      ,
+        comment: 'literal block'
+        name: 'markup.raw.asciidoc'
+        begin: '^(\\.{4})\\s*$'
+        patterns: [
+          include: '#block-callout'
+        ]
+        end: '^(\\1)$'
       ]
-      end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+      end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
 
     # add listing block
     codeBlocks.push

--- a/lib/code-block-generator.coffee
+++ b/lib/code-block-generator.coffee
@@ -25,6 +25,8 @@ module.exports =
         patterns: [
           include: '#block-callout'
         ,
+          include: '#include-directive'
+        ,
           include: "#{lang.type}.#{lang.code}"
         ]
         end: '^(\\1)$'
@@ -35,6 +37,8 @@ module.exports =
         patterns: [
           include: '#block-callout'
         ,
+          include: '#include-directive'
+        ,
           include: "#{lang.type}.#{lang.code}"
         ]
         end: '^(\\1)$'
@@ -44,6 +48,8 @@ module.exports =
         contentName: "#{lang.type}.embedded.#{lang.code}"
         patterns: [
           include: '#block-callout'
+        ,
+          include: '#include-directive'
         ,
           include: "#{lang.type}.#{lang.code}"
         ]
@@ -72,6 +78,8 @@ module.exports =
         begin: '^(-{4,})\\s*$'
         patterns: [
           include: '#block-callout'
+        ,
+          include: '#include-directive'
         ]
         end: '(?<=\\1)'
       ,
@@ -80,6 +88,8 @@ module.exports =
         begin: '^(-{2})\\s*$'
         patterns: [
           include: '#block-callout'
+        ,
+          include: '#include-directive'
         ]
         end: '^(\\1)$'
       ,
@@ -88,6 +98,8 @@ module.exports =
         begin: '^(\\.{4})\\s*$'
         patterns: [
           include: '#block-callout'
+        ,
+          include: '#include-directive'
         ]
         end: '^(\\1)$'
       ]
@@ -101,6 +113,8 @@ module.exports =
         0: name: 'support.asciidoc'
       patterns: [
         include: '#block-callout'
+      ,
+        include: '#include-directive'
       ]
       end: '^(\\1)$'
       endCaptures:

--- a/spec/blocks/source-literal-grammar-spec.coffee
+++ b/spec/blocks/source-literal-grammar-spec.coffee
@@ -1,0 +1,92 @@
+fdescribe 'Source literal', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes when', ->
+
+    it 'is followed by others grammar parts', ->
+      tokens = grammar.tokenizeLines '''
+                                      [source,shell]
+                                      ....
+                                      ls -l
+                                      cd ..
+                                      ....
+                                      <1> *Grammars* _definition_
+                                      <2> *CoffeeLint* _rules_
+                                      '''
+      expect(tokens).toHaveLength 7 # Number of lines
+      expect(tokens[0]).toHaveLength 5
+      expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'markup.heading.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: 'source', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: ',', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'markup.heading.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[0][3]).toEqualJson value: 'shell', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[0][4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'markup.heading.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
+      expect(tokens[3]).toHaveLength 1
+      expect(tokens[3][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
+      expect(tokens[4]).toHaveLength 2
+      expect(tokens[4][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
+      expect(tokens[4][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
+      expect(tokens[5]).toHaveLength 11
+      expect(tokens[5][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[5][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[5][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[5][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[5][4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5][5]).toEqualJson value: 'Grammars', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[5][6]).toEqualJson value: '*', scopes: [ 'source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5][7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[5][8]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5][9]).toEqualJson value: 'definition', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
+      expect(tokens[5][10]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5]).toHaveLength 11
+      expect(tokens[6][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[6][1]).toEqualJson value: '2', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[6][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[6][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[6][4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[6][5]).toEqualJson value: 'CoffeeLint', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[6][6]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[6][7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[6][8]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[6][9]).toEqualJson value: 'rules', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
+      expect(tokens[6][10]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'contains substitutions in additional attributes', ->
+      tokens = grammar.tokenizeLines '''
+        [source,java,subs="{markup-in-source}"]
+        ....
+        System.out.println("Hello *strong* text").
+        ....
+        '''
+      expect(tokens).toHaveLength 4 # Number of lines
+      expect(tokens[0]).toHaveLength 9
+      expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: 'source', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: ',', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[0][3]).toEqualJson value: 'java', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[0][4]).toEqualJson value: ',', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[0][5]).toEqualJson value: 'subs="', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[0][6]).toEqualJson value: '{markup-in-source}', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc', 'markup.substitution.attribute-reference.asciidoc']
+      expect(tokens[0][7]).toEqualJson value: '"', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[0][8]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'markup.heading.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'System.out.println("Hello *strong* text").', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'source.embedded.java']
+      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
+      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']

--- a/spec/blocks/source-literal-grammar-spec.coffee
+++ b/spec/blocks/source-literal-grammar-spec.coffee
@@ -1,4 +1,4 @@
-fdescribe 'Source literal', ->
+describe 'Source literal', ->
   grammar = null
 
   beforeEach ->

--- a/spec/code-block-generator-spec.coffee
+++ b/spec/code-block-generator-spec.coffee
@@ -28,6 +28,8 @@ describe 'Code block generator', ->
           begin: '^(-{4,})\\s*$'
           patterns: [
             include: '#block-callout'
+          ,
+            include: '#include-directive'
           ]
           end: '(?<=\\1)'
         ,
@@ -36,10 +38,22 @@ describe 'Code block generator', ->
           begin: '^(-{2})\\s*$'
           patterns: [
             include: '#block-callout'
+          ,
+            include: '#include-directive'
+          ]
+          end: '^(\\1)$'
+        ,
+          comment: 'literal block'
+          name: 'markup.raw.asciidoc'
+          begin: '^(\\.{4})\\s*$'
+          patterns: [
+            include: '#block-callout'
+          ,
+            include: '#include-directive'
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
 
     it 'should generate listing block', ->
       languages = []
@@ -52,6 +66,8 @@ describe 'Code block generator', ->
           0: name: 'support.asciidoc'
         patterns: [
           include: '#block-callout'
+        ,
+          include: '#include-directive'
         ]
         end: '^(\\1)$'
         endCaptures:
@@ -85,6 +101,8 @@ describe 'Code block generator', ->
           patterns: [
             include: '#block-callout'
           ,
+            include: '#include-directive'
+          ,
             include: "source.js"
           ]
           end: '^(\\1)$'
@@ -95,11 +113,25 @@ describe 'Code block generator', ->
           patterns: [
             include: '#block-callout'
           ,
+            include: '#include-directive'
+          ,
+            include: "source.js"
+          ]
+          end: '^(\\1)$'
+        ,
+          comment: 'literal block'
+          begin: '^(\\.{4})\\s*$'
+          contentName: "source.embedded.js"
+          patterns: [
+            include: '#block-callout'
+          ,
+            include: '#include-directive'
+          ,
             include: "source.js"
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
 
     it 'should generate C++ code block', ->
       languages = [
@@ -129,6 +161,8 @@ describe 'Code block generator', ->
           patterns: [
             include: '#block-callout'
           ,
+            include: '#include-directive'
+          ,
             include: "source.cpp"
           ]
           end: '^(\\1)$'
@@ -139,11 +173,25 @@ describe 'Code block generator', ->
           patterns: [
             include: '#block-callout'
           ,
+            include: '#include-directive'
+          ,
+            include: "source.cpp"
+          ]
+          end: '^(\\1)$'
+        ,
+          comment: 'literal block'
+          begin: '^(\\.{4})\\s*$'
+          contentName: "source.embedded.cpp"
+          patterns: [
+            include: '#block-callout'
+          ,
+            include: '#include-directive'
+          ,
             include: "source.cpp"
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
 
   describe 'with Markdown syntax', ->
 

--- a/spec/inlines/general-block-macro-grammar-spec.coffee
+++ b/spec/inlines/general-block-macro-grammar-spec.coffee
@@ -18,31 +18,32 @@ describe 'Should tokenizes general block macro when', ->
 
   it 'reference a gist', ->
     {tokens} = grammar.tokenizeLine 'gist::123456[]'
-    expect(tokens).toHaveLength 4
+    expect(tokens).toHaveLength 5
     expect(tokens[0]).toEqualJson value: 'gist', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
     expect(tokens[2]).toEqualJson value: '123456', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[]', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
 
   it 'reference an image', ->
     {tokens} = grammar.tokenizeLine 'image::filename.png[Caption]'
     expect(tokens).toHaveLength 6
     expect(tokens[0]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
     expect(tokens[2]).toEqualJson value: 'filename.png', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
     expect(tokens[4]).toEqualJson value: 'Caption', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
 
   it 'reference a video', ->
     {tokens} = grammar.tokenizeLine 'video::http://youtube.com/12345[Cats vs Dogs]'
     expect(tokens).toHaveLength 6
     expect(tokens[0]).toEqualJson value: 'video', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
     expect(tokens[2]).toEqualJson value: 'http://youtube.com/12345', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
     expect(tokens[4]).toEqualJson value: 'Cats vs Dogs', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc']
+    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
 
   it 'not at the line beginning (invalid context)', ->
     {tokens} = grammar.tokenizeLine 'foo image::filename.png[Caption]'

--- a/spec/partials/block-callout-grammar-spec.coffee
+++ b/spec/partials/block-callout-grammar-spec.coffee
@@ -35,23 +35,26 @@ describe 'Should tokenizes callout in code block when', ->
     expect(tokens[0][4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'markup.heading.asciidoc']
     expect(tokens[1]).toHaveLength 1
     expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc']
-    expect(tokens[2]).toHaveLength 4
-    expect(tokens[2][0]).toEqualJson value: 'var http = require(\'http\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[2][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[2][2]).toEqualJson value: '1', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[2][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[3]).toHaveLength 4
-    expect(tokens[3][0]).toEqualJson value: 'http.createServer(function (req, res) { ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[3][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[3][2]).toEqualJson value: '2', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[3][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[2]).toHaveLength 5
+    expect(tokens[2][0]).toEqualJson value: 'var http = require(\'http\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[2][1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc']
+    expect(tokens[2][2]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[2][3]).toEqualJson value: '1', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[2][4]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[3]).toHaveLength 5
+    expect(tokens[3][0]).toEqualJson value: 'http.createServer(function (req, res) {', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[2][1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc']
+    expect(tokens[3][2]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[3][3]).toEqualJson value: '2', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[3][4]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[4]).toHaveLength 1
     expect(tokens[4][0]).toEqualJson value: '  res.end(\'Hello World', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[5]).toHaveLength 4
-    expect(tokens[5][0]).toEqualJson value: '\'); ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[5][1]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[5][2]).toEqualJson value: '3', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[5][3]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5]).toHaveLength 5
+    expect(tokens[5][0]).toEqualJson value: '\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
+    expect(tokens[2][1]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc']
+    expect(tokens[5][2]).toEqualJson value: '<', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
+    expect(tokens[5][3]).toEqualJson value: '3', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.numeric.asciidoc']
+    expect(tokens[5][4]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[6]).toHaveLength 1
     expect(tokens[6][0]).toEqualJson value: '}).listen(1337, \'127.0.0.1\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
     expect(tokens[7]).toHaveLength 2


### PR DESCRIPTION
## Description

Source block delimiter with literal delimiter.

~~Bonus: inception mode (highlight asciidoc source in asciidoc source block...)~~

## Syntax example

```adoc
= Source block delimiter ....

== Exemple

[source,adoc]
....
:testdir: ${project.build.testSourceDirectory} // <1>
:testpkg: {testdir}/org/asciidoctor // <2>

[source,java]
----
include::{testpkg}/WhenAttributesAreUsed.java[tag=uri-scheme] // <3>
----
<1> Positionne l'attribut permettant de masquer le schéma sur les liens
....

// <1> Utilise une variable du build Maven (filtering)
// <2> Réutilise la variable définie juste au dessus pour ajouter le package
// <3> Précise le tag à utiliser (possibilité de préciser plusieurs tag séparé par des virgules)

== Résultat

:testpkg: src/test/java/org/asciidoctor

[source,java,indent=0]
----
include::{testpkg}/WhenAttributesAreUsed.java[tags=uri-scheme]
----
<1> Positionne l'attribut permettant de masquer le schéma sur les liens
```

## Screenshots

![capture du 2016-05-27 00-03-36](https://cloud.githubusercontent.com/assets/5674651/15591651/88dcdfc0-239e-11e6-816b-862c643c161a.png)

Fix #146