### PR TITLE
refactor: comment grammars review

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -361,17 +361,17 @@ repository:
     patterns: [
       {
         name: "comment.block.asciidoc"
-        begin: "(^/{4,}$)"
+        begin: "^(/{4,})$"
         patterns: [
           {
             include: "#inlines"
           }
         ]
-        end: "\\1"
+        end: "^\\1$"
       }
       {
         name: "comment.inline.asciidoc"
-        match: "^/{2}\\p{Blank}(.*)$"
+        match: "^/{2}([^/].*)?$"
       }
     ]
   "hard-break-backslash":

--- a/grammars/repositories/partials/comment-grammar.cson
+++ b/grammars/repositories/partials/comment-grammar.cson
@@ -13,16 +13,16 @@ patterns: [
   #   ////
   #
   name: 'comment.block.asciidoc'
-  begin: '(^/{4,}$)'
+  begin: '^(/{4,})$'
   patterns: [
     include: '#inlines'
   ]
-  end: '\\1'
+  end: '^\\1$'
 ,
   # Matches single line comments
   #
   # // A single-line comment
   #
   name: 'comment.inline.asciidoc'
-  match: '^\/{2}\\p{Blank}(.*)$'
+  match: '^\/{2}([^\/].*)?$'
 ]

--- a/spec/blocks/example-grammar-spec.coffee
+++ b/spec/blocks/example-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes example block when', ->
+describe 'Example block', ->
   grammar = null
 
   beforeEach ->
@@ -8,38 +8,36 @@ describe 'Should tokenizes example block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains others grammars', ->
-    tokens = grammar.tokenizeLines '''
-      ====
-      A multi-line *example*.
+  describe 'Should tokenizes when', ->
 
-      Notice it's a _delimited_ block.
-      ====
-      '''
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[1]).toHaveLength 5
-    expect(tokens[1][0]).toEqualJson value: 'A multi-line ', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[1][1]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1][2]).toEqualJson value: 'example', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
-    expect(tokens[1][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[3]).toHaveLength 5
-    expect(tokens[3][0]).toEqualJson value: 'Notice it\'s a ', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[3][1]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3][2]).toEqualJson value: 'delimited', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
-    expect(tokens[3][3]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3][4]).toEqualJson value: ' block.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-    expect(tokens[4]).toHaveLength 1
-    expect(tokens[4][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+    it 'contains others grammars', ->
+      tokens = grammar.tokenizeLines '''
+        ====
+        A multi-line *example*.
+
+        Notice it's a _delimited_ block.
+        ====
+        '''
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[1]).toHaveLength 5
+      expect(tokens[1][0]).toEqualJson value: 'A multi-line ', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[1][1]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1][2]).toEqualJson value: 'example', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[1][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[3]).toHaveLength 5
+      expect(tokens[3][0]).toEqualJson value: 'Notice it\'s a ', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[3][1]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3][2]).toEqualJson value: 'delimited', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
+      expect(tokens[3][3]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.example.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3][4]).toEqualJson value: ' block.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[4]).toHaveLength 1
+      expect(tokens[4][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']

--- a/spec/blocks/front-matter-grammar-spec.coffee
+++ b/spec/blocks/front-matter-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes front matter block when', ->
+describe 'Front matter block', ->
   grammar = null
 
   beforeEach ->
@@ -8,30 +8,28 @@ describe 'Should tokenizes front matter block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains others grammars', ->
-    tokens = grammar.tokenizeLines '''
-      ---
-      title:   "Free Operating Systems: A Comparison and Overview"
-      date:    2016-04-19 +1000
-      layout:  post
-      ---
-      '''
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqualJson value: '---', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
-    expect(tokens[1]).toHaveLength 1
-    expect(tokens[1][0]).toEqualJson value: 'title:   "Free Operating Systems: A Comparison and Overview"', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
-    expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqualJson value: 'date:    2016-04-19 +1000', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
-    expect(tokens[3]).toHaveLength 1
-    expect(tokens[3][0]).toEqualJson value: 'layout:  post', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
-    expect(tokens[4]).toHaveLength 1
-    expect(tokens[4][0]).toEqualJson value: '---', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
+  describe 'Should tokenizes when', ->
+
+    it 'contains others grammars', ->
+      tokens = grammar.tokenizeLines '''
+        ---
+        title:   "Free Operating Systems: A Comparison and Overview"
+        date:    2016-04-19 +1000
+        layout:  post
+        ---
+        '''
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: '---', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: 'title:   "Free Operating Systems: A Comparison and Overview"', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'date:    2016-04-19 +1000', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
+      expect(tokens[3]).toHaveLength 1
+      expect(tokens[3][0]).toEqualJson value: 'layout:  post', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']
+      expect(tokens[4]).toHaveLength 1
+      expect(tokens[4][0]).toEqualJson value: '---', scopes: ['source.asciidoc', 'markup.block.front-matter.asciidoc']

--- a/spec/blocks/literal-grammar-spec.coffee
+++ b/spec/blocks/literal-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes literal block when', ->
+describe 'Literal block', ->
   grammar = null
 
   beforeEach ->
@@ -8,24 +8,22 @@ describe 'Should tokenizes literal block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains simple phrase', ->
-    tokens = grammar.tokenizeLines '''
-      ....
-      Daleks EXTERMINATE in monospace!
-      ....
-      '''
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-    expect(tokens[1]).toHaveLength 1
-    expect(tokens[1][0]).toEqualJson value: 'Daleks EXTERMINATE in monospace!', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-    expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
+  describe 'Should tokenizes when', ->
+
+    it 'contains simple phrase', ->
+      tokens = grammar.tokenizeLines '''
+        ....
+        Daleks EXTERMINATE in monospace!
+        ....
+        '''
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: 'Daleks EXTERMINATE in monospace!', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']

--- a/spec/blocks/open-block-grammar-spec.coffee
+++ b/spec/blocks/open-block-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes open block when', ->
+describe 'Open block', ->
   grammar = null
 
   beforeEach ->
@@ -8,24 +8,22 @@ describe 'Should tokenizes open block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains simple phrase', ->
-    tokens = grammar.tokenizeLines '''
-      --
-      foobar, foobar and foobar
-      --
-      '''
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
-    expect(tokens[1]).toHaveLength 1
-    expect(tokens[1][0]).toEqualJson value: 'foobar, foobar and foobar', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
-    expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+  describe 'Should tokenizes when', ->
+
+    it 'contains simple phrase', ->
+      tokens = grammar.tokenizeLines '''
+        --
+        foobar, foobar and foobar
+        --
+        '''
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: 'foobar, foobar and foobar', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']

--- a/spec/blocks/sidebar-grammar-spec.coffee
+++ b/spec/blocks/sidebar-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes sidebar block when', ->
+describe 'Sidebar block', ->
   grammar = null
 
   beforeEach ->
@@ -8,38 +8,36 @@ describe 'Should tokenizes sidebar block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains others grammars', ->
-    tokens = grammar.tokenizeLines '''
-      ****
-      A multi-line *sidebar*.
+  describe 'Should tokenizes when', ->
 
-      Notice it's a _delimited_ block.
-      ****
-      '''
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toHaveLength 1
-    expect(tokens[0][0]).toEqualJson value: '****', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[1]).toHaveLength 5
-    expect(tokens[1][0]).toEqualJson value: 'A multi-line ', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[1][1]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1][2]).toEqualJson value: 'sidebar', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
-    expect(tokens[1][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[2]).toHaveLength 1
-    expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[3]).toHaveLength 5
-    expect(tokens[3][0]).toEqualJson value: 'Notice it\'s a ', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[3][1]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3][2]).toEqualJson value: 'delimited', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
-    expect(tokens[3][3]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3][4]).toEqualJson value: ' block.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-    expect(tokens[4]).toHaveLength 1
-    expect(tokens[4][0]).toEqualJson value: '****', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+    it 'contains others grammars', ->
+      tokens = grammar.tokenizeLines '''
+        ****
+        A multi-line *sidebar*.
+
+        Notice it's a _delimited_ block.
+        ****
+        '''
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: '****', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[1]).toHaveLength 5
+      expect(tokens[1][0]).toEqualJson value: 'A multi-line ', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[1][1]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1][2]).toEqualJson value: 'sidebar', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[1][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[3]).toHaveLength 5
+      expect(tokens[3][0]).toEqualJson value: 'Notice it\'s a ', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[3][1]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3][2]).toEqualJson value: 'delimited', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
+      expect(tokens[3][3]).toEqualJson value: '_', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3][4]).toEqualJson value: ' block.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
+      expect(tokens[4]).toHaveLength 1
+      expect(tokens[4][0]).toEqualJson value: '****', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']

--- a/spec/inlines/anchor-macro-grammar-spec.coffee
+++ b/spec/inlines/anchor-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes anchor macro when', ->
+describe 'Anchor macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,52 +8,50 @@ describe 'Should tokenizes anchor macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple anchor', ->
-    {tokens} = grammar.tokenizeLine 'foo [[idname]] bar'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '[[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[4]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'extends anchor', ->
-    {tokens} = grammar.tokenizeLine 'foo [[idname,Reference Text]] bar'
-    expect(tokens).toHaveLength 7
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '[[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
-    expect(tokens[3]).toEqualJson value: ',', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'Reference Text', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[6]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'simple anchor', ->
+      {tokens} = grammar.tokenizeLine 'foo [[idname]] bar'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'simple anchor macro', ->
-    {tokens} = grammar.tokenizeLine 'foo anchor:idname[] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'anchor', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'extends anchor', ->
+      {tokens} = grammar.tokenizeLine 'foo [[idname,Reference Text]] bar'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
+      expect(tokens[3]).toEqualJson value: ',', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Reference Text', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[6]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'extends anchor macro', ->
-    {tokens} = grammar.tokenizeLine 'foo anchor:idname[Reference Text] bar'
-    expect(tokens).toHaveLength 8
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'anchor', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'Reference Text', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'simple anchor macro', ->
+      {tokens} = grammar.tokenizeLine 'foo anchor:idname[] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'anchor', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[]', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+
+    it 'extends anchor macro', ->
+      {tokens} = grammar.tokenizeLine 'foo anchor:idname[Reference Text] bar'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'anchor', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'idname', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'markup.blockid.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'Reference Text', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.anchor.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']

--- a/spec/inlines/bibliography-anchor-grammar-spec.coffee
+++ b/spec/inlines/bibliography-anchor-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes bibliography-anchor when', ->
+describe 'Bibliography anchor', ->
   grammar = null
 
   beforeEach ->
@@ -8,19 +8,17 @@ describe 'Should tokenizes bibliography-anchor when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'is in a phrase', ->
-    {tokens} = grammar.tokenizeLine 'foobar [[[bib-ref]]] foobar'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '[[[', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'bib-ref', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'markup.biblioref.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']]]', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[4]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
+
+    it 'is in a phrase', ->
+      {tokens} = grammar.tokenizeLine 'foobar [[[bib-ref]]] foobar'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '[[[', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'bib-ref', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'markup.biblioref.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']]]', scopes: ['source.asciidoc', 'bibliography-anchor.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']

--- a/spec/inlines/characters-grammar-spec.coffee
+++ b/spec/inlines/characters-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes characters when', ->
+describe 'Characters', ->
   grammar = null
 
   beforeEach ->
@@ -8,24 +8,22 @@ describe 'Should tokenizes characters when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'is in a phrase', ->
-    {tokens} = grammar.tokenizeLine 'Dungeons &amp; Dragons'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'Dungeons ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '&', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc', 'constant.character.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'amp', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc']
-    expect(tokens[3]).toEqualJson value: ';', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc', 'constant.character.asciidoc']
-    expect(tokens[4]).toEqualJson value: ' Dragons', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'contains space (invalid context)', ->
-    {tokens} = grammar.tokenizeLine 'Dungeons &a mp; Dragons'
-    expect(tokens).toHaveLength 1
-    expect(tokens[0]).toEqualJson value: 'Dungeons &a mp; Dragons', scopes: ['source.asciidoc']
+    it 'is in a phrase', ->
+      {tokens} = grammar.tokenizeLine 'Dungeons &amp; Dragons'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'Dungeons ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '&', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc', 'constant.character.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'amp', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc']
+      expect(tokens[3]).toEqualJson value: ';', scopes: ['source.asciidoc', 'markup.character-reference.asciidoc', 'constant.character.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' Dragons', scopes: ['source.asciidoc']
+
+    it 'contains space (invalid context)', ->
+      {tokens} = grammar.tokenizeLine 'Dungeons &a mp; Dragons'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: 'Dungeons &a mp; Dragons', scopes: ['source.asciidoc']

--- a/spec/inlines/emphasis-grammar-spec.coffee
+++ b/spec/inlines/emphasis-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe '_emphasis_ text', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/inlines/footnote-macro-grammar-spec.coffee
+++ b/spec/inlines/footnote-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes footnote macro when', ->
+describe 'Footnote macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,42 +8,40 @@ describe 'Should tokenizes footnote macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple footnote', ->
-    {tokens} = grammar.tokenizeLine 'footnote:[text]'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'simple footnote with formatted text', ->
-    {tokens} = grammar.tokenizeLine 'footnote:[*text*]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    it 'simple footnote', ->
+      {tokens} = grammar.tokenizeLine 'footnote:[text]'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
 
-  it 'simple footnoteref with id and text', ->
-    {tokens} = grammar.tokenizeLine 'footnoteref:[id,text]'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'id,text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    it 'simple footnote with formatted text', ->
+      {tokens} = grammar.tokenizeLine 'footnote:[*text*]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'footnote', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
 
-  it 'simple footnoteref with id', ->
-    {tokens} = grammar.tokenizeLine 'footnoteref:[id]'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'id', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+    it 'simple footnoteref with id and text', ->
+      {tokens} = grammar.tokenizeLine 'footnoteref:[id,text]'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'id,text', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+
+    it 'simple footnoteref with id', ->
+      {tokens} = grammar.tokenizeLine 'footnoteref:[id]'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: 'footnoteref', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'id', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.footnote.asciidoc']

--- a/spec/inlines/general-block-macro-grammar-spec.coffee
+++ b/spec/inlines/general-block-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes general block macro when', ->
+describe 'General block macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,44 +8,42 @@ describe 'Should tokenizes general block macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'reference a gist', ->
-    {tokens} = grammar.tokenizeLine 'gist::123456[]'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'gist', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[2]).toEqualJson value: '123456', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'reference an image', ->
-    {tokens} = grammar.tokenizeLine 'image::filename.png[Caption]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'filename.png', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'Caption', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+    it 'reference a gist', ->
+      {tokens} = grammar.tokenizeLine 'gist::123456[]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'gist', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[2]).toEqualJson value: '123456', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
 
-  it 'reference a video', ->
-    {tokens} = grammar.tokenizeLine 'video::http://youtube.com/12345[Cats vs Dogs]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'video', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'http://youtube.com/12345', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'Cats vs Dogs', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+    it 'reference an image', ->
+      {tokens} = grammar.tokenizeLine 'image::filename.png[Caption]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'filename.png', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Caption', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
 
-  it 'not at the line beginning (invalid context)', ->
-    {tokens} = grammar.tokenizeLine 'foo image::filename.png[Caption]'
-    expect(tokens).toHaveLength 1
-    expect(tokens[0]).toEqualJson value: 'foo image::filename.png[Caption]', scopes: ['source.asciidoc']
+    it 'reference a video', ->
+      {tokens} = grammar.tokenizeLine 'video::http://youtube.com/12345[Cats vs Dogs]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'video', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: '::', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'http://youtube.com/12345', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Cats vs Dogs', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.block.general.asciidoc', 'punctuation.separator.asciidoc']
+
+    it 'not at the line beginning (invalid context)', ->
+      {tokens} = grammar.tokenizeLine 'foo image::filename.png[Caption]'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: 'foo image::filename.png[Caption]', scopes: ['source.asciidoc']

--- a/spec/inlines/image-macro-grammar-spec.coffee
+++ b/spec/inlines/image-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes image/icon macro when', ->
+describe 'Image/icon macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,46 +8,44 @@ describe 'Should tokenizes image/icon macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'reference a relative path to an image', ->
-    {tokens} = grammar.tokenizeLine 'foo image:filename.png[Alt Text] bar'
-    expect(tokens).toHaveLength 8
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'filename.png', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'Alt Text', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'reference a url to an image', ->
-    {tokens} = grammar.tokenizeLine 'foo image:http://example.com/images/filename.png[Alt Text] bar'
-    expect(tokens).toHaveLength 8
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'http://example.com/images/filename.png', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'Alt Text', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'reference a relative path to an image', ->
+      {tokens} = grammar.tokenizeLine 'foo image:filename.png[Alt Text] bar'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'filename.png', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'Alt Text', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'reference an icon', ->
-    {tokens} = grammar.tokenizeLine 'foo icon:github[large] bar'
-    expect(tokens).toHaveLength 8
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'icon', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'github', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'large', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'reference a url to an image', ->
+      {tokens} = grammar.tokenizeLine 'foo image:http://example.com/images/filename.png[Alt Text] bar'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'image', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'http://example.com/images/filename.png', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'Alt Text', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+
+    it 'reference an icon', ->
+      {tokens} = grammar.tokenizeLine 'foo icon:github[large] bar'
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'icon', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'github', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[4]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'large', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[6]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.image.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' bar', scopes: ['source.asciidoc']

--- a/spec/inlines/kbd-macro-grammar-spec.coffee
+++ b/spec/inlines/kbd-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes keyboard macro when', ->
+describe 'Keyboard macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,50 +8,48 @@ describe 'Should tokenizes keyboard macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple key', ->
-    {tokens} = grammar.tokenizeLine 'foo kbd:[F3] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'F3', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'several keys', ->
-    {tokens} = grammar.tokenizeLine 'foo kbd:[Ctrl+Shift+T] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'Ctrl+Shift+T', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'simple key', ->
+      {tokens} = grammar.tokenizeLine 'foo kbd:[F3] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'F3', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'contains ]', ->
-    {tokens} = grammar.tokenizeLine 'foo kbd:[Ctrl+\]] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'Ctrl+', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[5]).toEqualJson value: '] bar', scopes: ['source.asciidoc']
+    it 'several keys', ->
+      {tokens} = grammar.tokenizeLine 'foo kbd:[Ctrl+Shift+T] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Ctrl+Shift+T', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'contains a label', ->
-    {tokens} = grammar.tokenizeLine 'foo btn:[Save] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'btn', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'Save', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'contains ]', ->
+      {tokens} = grammar.tokenizeLine 'foo kbd:[Ctrl+\]] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'kbd', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Ctrl+', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[5]).toEqualJson value: '] bar', scopes: ['source.asciidoc']
+
+    it 'contains a label', ->
+      {tokens} = grammar.tokenizeLine 'foo btn:[Save] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'btn', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'Save', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.kbd.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']

--- a/spec/inlines/link-grammar-spec.coffee
+++ b/spec/inlines/link-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes text link when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/inlines/mark-grammar-spec.coffee
+++ b/spec/inlines/mark-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'mark text', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  it 'parses the grammar', ->
-    expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe 'source.asciidoc'
-
   describe 'Should tokenizes constrained mark text', ->
 
     it 'when constrained mark text', ->

--- a/spec/inlines/menu-macro-grammar-spec.coffee
+++ b/spec/inlines/menu-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes menu macro when', ->
+describe 'Menu macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,40 +8,38 @@ describe 'Should tokenizes menu macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains File item', ->
-    {tokens} = grammar.tokenizeLine 'menu:File[New...]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'File', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'New...', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'contains View item', ->
-    {tokens} = grammar.tokenizeLine 'menu:View[Page Style > No Style]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'View', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'Page Style > No Style', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+    it 'contains File item', ->
+      {tokens} = grammar.tokenizeLine 'menu:File[New...]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'File', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'New...', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
 
-  it 'contains View item comma', ->
-    {tokens} = grammar.tokenizeLine 'menu:View[Page Style, No Style]'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'View', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'Page Style, No Style', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+    it 'contains View item', ->
+      {tokens} = grammar.tokenizeLine 'menu:View[Page Style > No Style]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'View', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Page Style > No Style', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+
+    it 'contains View item comma', ->
+      {tokens} = grammar.tokenizeLine 'menu:View[Page Style, No Style]'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'menu', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: ':', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'View', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'markup.link.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'Page Style, No Style', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.other.menu.asciidoc']

--- a/spec/inlines/monospace-grammar-spec.coffee
+++ b/spec/inlines/monospace-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe '`monospace`', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/inlines/passthrough-macro-grammar-spec.coffee
+++ b/spec/inlines/passthrough-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes passthrough macro when', ->
+describe 'Passthrough macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,48 +8,46 @@ describe 'Should tokenizes passthrough macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'as attribute, started at the beginning of the line and without text after.', ->
-    {tokens} = grammar.tokenizeLine 'pass:q,c[<u>underline *me*</u>]'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'pass:', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'q,c', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'markup.meta.attribute-list.asciidoc']
-    expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
-    expect(tokens[3]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'as attribute, in a phrase.', ->
-    {tokens} = grammar.tokenizeLine 'A pass:o,x[<u>underline *me*</u>] followed by normal content.'
-    expect(tokens).toHaveLength 7
-    expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'pass:', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'o,x', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'markup.meta.attribute-list.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
-    expect(tokens[4]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
-    expect(tokens[6]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']
+    it 'as attribute, started at the beginning of the line and without text after.', ->
+      {tokens} = grammar.tokenizeLine 'pass:q,c[<u>underline *me*</u>]'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'pass:', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'q,c', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[2]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
+      expect(tokens[3]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
 
-  it 'as triple-plus, in a phrase.', ->
-    {tokens} = grammar.tokenizeLine 'A +++<u>underline *me*</u>+++ followed by normal content.'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '+++', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: '+++', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[4]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']
+    it 'as attribute, in a phrase.', ->
+      {tokens} = grammar.tokenizeLine 'A pass:o,x[<u>underline *me*</u>] followed by normal content.'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'pass:', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'o,x', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
+      expect(tokens[4]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc']
+      expect(tokens[6]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']
 
-  it 'as double-dollar, in a phrase.', ->
-    {tokens} = grammar.tokenizeLine 'A $$<u>underline *me*</u>$$ followed by normal content.'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '$$', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[3]).toEqualJson value: '$$', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
-    expect(tokens[4]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']
+    it 'as triple-plus, in a phrase.', ->
+      {tokens} = grammar.tokenizeLine 'A +++<u>underline *me*</u>+++ followed by normal content.'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '+++', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: '+++', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']
+
+    it 'as double-dollar, in a phrase.', ->
+      {tokens} = grammar.tokenizeLine 'A $$<u>underline *me*</u>$$ followed by normal content.'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: 'A ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '$$', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: '<u>underline *me*</u>', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[3]).toEqualJson value: '$$', scopes: ['source.asciidoc', 'markup.macro.inline.passthrough.asciidoc', 'support.constant.asciidoc']
+      expect(tokens[4]).toEqualJson value: ' followed by normal content.', scopes: ['source.asciidoc']

--- a/spec/inlines/stem-grammar-spec.coffee
+++ b/spec/inlines/stem-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes stem macro when', ->
+describe 'Stem macro', ->
   grammar = null
 
   beforeEach ->
@@ -8,40 +8,38 @@ describe 'Should tokenizes stem macro when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains stem', ->
-    {tokens} = grammar.tokenizeLine 'foo stem:[x != 0] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'stem', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'x != 0', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+  describe 'Should tokenizes stem macro when', ->
 
-  it 'contains asciimath', ->
-    {tokens} = grammar.tokenizeLine 'foo asciimath:[x != 0] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'asciimath', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'x != 0', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'contains stem', ->
+      {tokens} = grammar.tokenizeLine 'foo stem:[x != 0] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'stem', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'x != 0', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
 
-  it 'contains latexmath', ->
-    {tokens} = grammar.tokenizeLine 'foo latexmath:[\\sqrt{4} = 2] bar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'latexmath', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[3]).toEqualJson value: '\\sqrt{4} = 2', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+    it 'contains asciimath', ->
+      {tokens} = grammar.tokenizeLine 'foo asciimath:[x != 0] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'asciimath', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'x != 0', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']
+
+    it 'contains latexmath', ->
+      {tokens} = grammar.tokenizeLine 'foo latexmath:[\\sqrt{4} = 2] bar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foo ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'latexmath', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: ':[', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[3]).toEqualJson value: '\\sqrt{4} = 2', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.macro.inline.stem.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' bar', scopes: ['source.asciidoc']

--- a/spec/inlines/strong-grammar-spec.coffee
+++ b/spec/inlines/strong-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe '*strong* text', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName('source.asciidoc')
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/inlines/subscript-grammar-spec.coffee
+++ b/spec/inlines/subscript-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes subscript when', ->
+describe 'Subscript', ->
   grammar = null
 
   beforeEach ->
@@ -8,34 +8,32 @@ describe 'Should tokenizes subscript when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple phrase', ->
-    {tokens} = grammar.tokenizeLine '~subscript~ is good'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
-    expect(tokens[2]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' is good', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'when having a [role] set on ~subscript~ text', ->
-    {tokens} = grammar.tokenizeLine '[role]~subscript~'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.meta.sub.attribute-list.asciidoc']
-    expect(tokens[1]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
-    expect(tokens[3]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+    it 'simple phrase', ->
+      {tokens} = grammar.tokenizeLine '~subscript~ is good'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
+      expect(tokens[2]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' is good', scopes: ['source.asciidoc']
 
-  it 'when having [role1 role2] set on ~subscript~ text', ->
-    {tokens} = grammar.tokenizeLine '[role1 role2]~subscript~'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.meta.sub.attribute-list.asciidoc']
-    expect(tokens[1]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
-    expect(tokens[3]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+    it 'when having a [role] set on ~subscript~ text', ->
+      {tokens} = grammar.tokenizeLine '[role]~subscript~'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.meta.sub.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
+      expect(tokens[3]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when having [role1 role2] set on ~subscript~ text', ->
+      {tokens} = grammar.tokenizeLine '[role1 role2]~subscript~'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.meta.sub.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'subscript', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc']
+      expect(tokens[3]).toEqualJson value: '~', scopes: ['source.asciidoc', 'markup.subscript.asciidoc', 'markup.sub.subscript.asciidoc', 'punctuation.definition.asciidoc']

--- a/spec/inlines/superscript-grammar-spec.coffee
+++ b/spec/inlines/superscript-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes superscript when', ->
+describe 'Superscript', ->
   grammar = null
 
   beforeEach ->
@@ -8,34 +8,32 @@ describe 'Should tokenizes superscript when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'simple phrase', ->
-    {tokens} = grammar.tokenizeLine '^superscript^ is good'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
-    expect(tokens[2]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' is good', scopes: ['source.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'when having a [role] set on ^superscript^ text', ->
-    {tokens} = grammar.tokenizeLine '[role]^superscript^'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.meta.super.attribute-list.asciidoc']
-    expect(tokens[1]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
-    expect(tokens[3]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+    it 'simple phrase', ->
+      {tokens} = grammar.tokenizeLine '^superscript^ is good'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
+      expect(tokens[2]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' is good', scopes: ['source.asciidoc']
 
-  it 'when having [role1 role2] set on ^superscript^ text', ->
-    {tokens} = grammar.tokenizeLine '[role1 role2]^superscript^'
-    expect(tokens).toHaveLength 4
-    expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.meta.super.attribute-list.asciidoc']
-    expect(tokens[1]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
-    expect(tokens[3]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+    it 'when having a [role] set on ^superscript^ text', ->
+      {tokens} = grammar.tokenizeLine '[role]^superscript^'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role]', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.meta.super.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
+      expect(tokens[3]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+
+    it 'when having [role1 role2] set on ^superscript^ text', ->
+      {tokens} = grammar.tokenizeLine '[role1 role2]^superscript^'
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toEqualJson value: '[role1 role2]', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.meta.super.attribute-list.asciidoc']
+      expect(tokens[1]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'superscript', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc']
+      expect(tokens[3]).toEqualJson value: '^', scopes: ['source.asciidoc', 'markup.superscript.asciidoc', 'markup.super.superscript.asciidoc', 'punctuation.definition.asciidoc']

--- a/spec/inlines/xref-macro-grammar-spec.coffee
+++ b/spec/inlines/xref-macro-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes xref when', ->
+describe 'xref', ->
   grammar = null
 
   beforeEach ->
@@ -8,31 +8,29 @@ describe 'Should tokenizes xref when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it '<<reference>> elements', ->
-    {tokens} = grammar.tokenizeLine 'foobar <<id,reftext>> foobar'
-    expect(tokens).toHaveLength 6
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: '<<', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'constant.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'id,', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'markup.meta.attribute-list.asciidoc']
-    expect(tokens[3]).toEqualJson value: 'reftext', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[4]).toEqualJson value: '>>', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'constant.asciidoc']
-    expect(tokens[5]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+  describe 'should tokenizes when', ->
 
-  it 'tokenizes xref:id[reference] elements', ->
-    {tokens} = grammar.tokenizeLine 'foobar xref:id[reftext] foobar'
-    expect(tokens).toHaveLength 7
-    expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'xref:', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: 'id', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'markup.meta.attribute-list.asciidoc']
-    expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'reftext', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'string.unquoted.asciidoc']
-    expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc']
-    expect(tokens[6]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+    it '<<reference>> elements', ->
+      {tokens} = grammar.tokenizeLine 'foobar <<id,reftext>> foobar'
+      expect(tokens).toHaveLength 6
+      expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: '<<', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'constant.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'id,', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[3]).toEqualJson value: 'reftext', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[4]).toEqualJson value: '>>', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'constant.asciidoc']
+      expect(tokens[5]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']
+
+    it 'tokenizes xref:id[reference] elements', ->
+      {tokens} = grammar.tokenizeLine 'foobar xref:id[reftext] foobar'
+      expect(tokens).toHaveLength 7
+      expect(tokens[0]).toEqualJson value: 'foobar ', scopes: ['source.asciidoc']
+      expect(tokens[1]).toEqualJson value: 'xref:', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[2]).toEqualJson value: 'id', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'markup.meta.attribute-list.asciidoc']
+      expect(tokens[3]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'reftext', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc', 'string.unquoted.asciidoc']
+      expect(tokens[5]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.reference.xref.asciidoc']
+      expect(tokens[6]).toEqualJson value: ' foobar', scopes: ['source.asciidoc']

--- a/spec/partials/attributes-grammar-spec.coffee
+++ b/spec/partials/attributes-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Attributes', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/block-callout-grammar-spec.coffee
+++ b/spec/partials/block-callout-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes callout in code block when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/block-title-grammar-spec.coffee
+++ b/spec/partials/block-title-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes block title when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/callout-list-item-grammar-spec.coffee
+++ b/spec/partials/callout-list-item-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes callout list item when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/comment-grammar-spec.coffee
+++ b/spec/partials/comment-grammar-spec.coffee
@@ -1,0 +1,56 @@
+describe 'Comments', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'inline comment', ->
+
+    describe 'Should tokenizes when', ->
+
+      it 'double slash following with space', ->
+        {tokens} = grammar.tokenizeLine '// a comment'
+        expect(tokens).toHaveLength 1
+        expect(tokens[0]).toEqualJson value: '// a comment', scopes: ['source.asciidoc', 'comment.inline.asciidoc']
+
+      it 'double slash not following with space', ->
+        {tokens} = grammar.tokenizeLine '//a comment'
+        expect(tokens).toHaveLength 1
+        expect(tokens[0]).toEqualJson value: '//a comment', scopes: ['source.asciidoc', 'comment.inline.asciidoc']
+
+    describe 'Should not tokenizes when', ->
+
+      it 'triple slash', ->
+        {tokens} = grammar.tokenizeLine '/// a comment'
+        expect(tokens).toHaveLength 1
+        expect(tokens[0]).toEqualJson value: '/// a comment', scopes: ['source.asciidoc']
+
+  describe 'comment block', ->
+
+    describe 'Should tokenizes when', ->
+
+      it 'simple block', ->
+        tokens = grammar.tokenizeLines '''
+          ////
+          A multi-line comment.
+
+          Notice it's a delimited block.
+          ////
+          '''
+        expect(tokens).toHaveLength 5
+        expect(tokens[0]).toHaveLength 1
+        expect(tokens[0][0]).toEqualJson value: '////', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+        expect(tokens[1]).toHaveLength 1
+        expect(tokens[1][0]).toEqualJson value: 'A multi-line comment.', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+        expect(tokens[2]).toHaveLength 1
+        expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+        expect(tokens[3]).toHaveLength 1
+        expect(tokens[3][0]).toEqualJson value: 'Notice it\'s a delimited block.', scopes: ['source.asciidoc', 'comment.block.asciidoc']

--- a/spec/partials/horizontal-rule-grammar-spec.coffee
+++ b/spec/partials/horizontal-rule-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'horizontal rule and page break', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
@@ -21,36 +17,36 @@ describe 'horizontal rule and page break', ->
     it 'contains quotes', ->
       {tokens} = grammar.tokenizeLine '\'\'\''
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '\'\'\'', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '\'\'\'', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
     it 'contains quotes with spaces', ->
       {tokens} = grammar.tokenizeLine '\' \' \''
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '\' \' \'', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '\' \' \'', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
     it 'contains asterisks', ->
       {tokens} = grammar.tokenizeLine '***'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '***', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '***', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
     it 'contains asterisks with spaces', ->
       {tokens} = grammar.tokenizeLine '* * *'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '* * *', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '* * *', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
     it 'contains hyphen', ->
       {tokens} = grammar.tokenizeLine '---'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '---', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '---', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
     it 'contains hyphen with spaces', ->
       {tokens} = grammar.tokenizeLine '- - -'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '- - -', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '- - -', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
 
   describe 'Should tokenizes page break when', ->
 
     it 'contains "lower than" symbol', ->
       {tokens} = grammar.tokenizeLine '<<<'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqual value: '<<<', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']
+      expect(tokens[0]).toEqualJson value: '<<<', scopes: ['source.asciidoc', 'constant.other.symbol.horizontal-rule.asciidoc']

--- a/spec/partials/line-break-grammar-spec.coffee
+++ b/spec/partials/line-break-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenize line break when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/list-ordered-grammar-spec.coffee
+++ b/spec/partials/list-ordered-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes ordered list bullets when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/list-unordered-grammar-spec.coffee
+++ b/spec/partials/list-unordered-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenizes unordered list bullets when', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/titles-grammar-spec.coffee
+++ b/spec/partials/titles-grammar-spec.coffee
@@ -10,10 +10,6 @@ describe 'Titles', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'

--- a/spec/partials/todo-list-grammar-spec.coffee
+++ b/spec/partials/todo-list-grammar-spec.coffee
@@ -8,10 +8,6 @@ describe 'Should tokenize todo lists', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
 
-  # convenience function during development
-  debug = (tokens) ->
-    console.log(JSON.stringify tokens, null, ' ')
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'


### PR DESCRIPTION
## Description

A line comment does not require a space after the comment prefix. However, it does require that the third character not be a forward slash.

## Syntax example

```adoc
//a comment
// a comment
/// not a comment
```

## Screenshots

![capture du 2016-05-31 09-15-35](https://cloud.githubusercontent.com/assets/5674651/15666282/43a1879c-2710-11e6-8b59-aff0ad68bfe0.png)

Fix #150 