### PR TITLE
feat: comment open block

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -53,6 +53,9 @@ repository:
         include: "#front-matter-block"
       }
       {
+        include: "#comment-open-block"
+      }
+      {
         include: "#admonition-paragraph"
       }
       {
@@ -1143,6 +1146,45 @@ repository:
           }
         ]
         end: "^\\p{Blank}*$"
+      }
+    ]
+  "comment-open-block":
+    patterns: [
+      {
+        name: "comment.block.asciidoc"
+        begin: "(?=(?>(?:^\\[(comment)((?:,|#|\\.|%)[^\\]]+)*\\]$)))"
+        patterns: [
+          {
+            match: "^\\[(comment)((?:,|#|\\.|%)([^,\\]]+))*\\]$"
+            captures:
+              "0":
+                patterns: [
+                  {
+                    include: "#block-attribute-inner"
+                  }
+                ]
+          }
+          {
+            include: "#inlines"
+          }
+          {
+            include: "#block-title"
+          }
+          {
+            comment: "open block"
+            begin: "^(-{2})\\s*$"
+            patterns: [
+              {
+                include: "#inlines"
+              }
+              {
+                include: "#list"
+              }
+            ]
+            end: "(?<=\\1)"
+          }
+        ]
+        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
       }
     ]
   "example-block":

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -35,6 +35,8 @@ repository:
     patterns: [
       include: '#front-matter-block'
     ,
+      include: '#comment-open-block'
+    ,
       include: '#admonition-paragraph'
     ,
       include: '#quote-paragraph'

--- a/grammars/repositories/blocks/comment-open-block-grammar.cson
+++ b/grammars/repositories/blocks/comment-open-block-grammar.cson
@@ -1,0 +1,29 @@
+key: 'comment-open-block'
+
+patterns: [
+    name: 'comment.block.asciidoc'
+    begin: '(?=(?>(?:^\\[(comment)((?:,|#|\\.|%)[^\\]]+)*\\]$)))'
+    patterns: [
+      match: '^\\[(comment)((?:,|#|\\.|%)([^,\\]]+))*\\]$'
+      captures:
+        0:
+          patterns: [
+            include: '#block-attribute-inner'
+          ]
+    ,
+      include: '#inlines'
+    ,
+      include: '#block-title'
+    ,
+      comment: 'open block'
+      begin: '^(-{2})\\s*$'
+      patterns: [
+        include: '#inlines'
+      ,
+        include: '#list'
+      ]
+      end: '(?<=\\1)'
+    ]
+    end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+  ,
+]

--- a/spec/blocks/comment-open-block-grammar-spec.coffee
+++ b/spec/blocks/comment-open-block-grammar-spec.coffee
@@ -1,0 +1,47 @@
+describe 'Comment open block', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes when', ->
+
+    it 'contains simple phrase', ->
+      tokens = grammar.tokenizeLines '''
+        [comment]
+        --
+        an open block comment.
+        an open block comment.
+
+        an open block comment.
+        --
+        foobar
+        '''
+      expect(tokens).toHaveLength 8
+      expect(tokens[0]).toHaveLength 3
+      expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: 'comment', scopes: ['source.asciidoc', 'comment.block.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: ']', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'an open block comment.', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[3]).toHaveLength 1
+      expect(tokens[3][0]).toEqualJson value: 'an open block comment.', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[4]).toHaveLength 1
+      expect(tokens[4][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[5]).toHaveLength 1
+      expect(tokens[5][0]).toEqualJson value: 'an open block comment.', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[6]).toHaveLength 2
+      expect(tokens[6][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[6][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+      expect(tokens[7]).toHaveLength 1
+      expect(tokens[7][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/partials/block-attribute-explicit-paragraph-grammar-spec.coffee
+++ b/spec/partials/block-attribute-explicit-paragraph-grammar-spec.coffee
@@ -78,9 +78,9 @@ describe 'Should tokenizes block attribute for explicit paragraph when', ->
   it 'use "comment" keyword', ->
     {tokens} = grammar.tokenizeLine '[comment]'
     expect(tokens).toHaveLength 3
-    expect(tokens[0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.heading.block-attribute.asciidoc']
-    expect(tokens[1]).toEqualJson value: 'comment', scopes: ['source.asciidoc', 'markup.heading.block-attribute.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
-    expect(tokens[2]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.heading.block-attribute.asciidoc']
+    expect(tokens[0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'comment.block.asciidoc']
+    expect(tokens[1]).toEqualJson value: 'comment', scopes: ['source.asciidoc', 'comment.block.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+    expect(tokens[2]).toEqualJson value: ']', scopes: ['source.asciidoc', 'comment.block.asciidoc']
 
   it 'use "example" keyword', ->
     {tokens} = grammar.tokenizeLine '[example]'


### PR DESCRIPTION
## Description

Highlighting for comment 'open block'.

## Syntax example

```adoc
foo

[comment]
--
an open block comment.
an open block comment.

an open block comment.
--

foo
```

## Screenshots

![capture du 2016-06-02 22-19-55](https://cloud.githubusercontent.com/assets/5674651/15759696/29508300-2910-11e6-9816-fe66935a9c81.png)
