### PR TITLE
Open block as asciidoc code block

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -1182,9 +1182,20 @@ repository:
   "open-block":
     patterns: [
       {
-        name: "markup.raw.open.asciidoc"
+        name: "markup.block.open.asciidoc"
         begin: "^(-{2})$"
+        beginCaptures:
+          "1":
+            name: "constant.other.symbol.asciidoc"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
         end: "^(\\1)$"
+        endCaptures:
+          "1":
+            name: "constant.other.symbol.asciidoc"
       }
     ]
   "passthrough-paragraph":

--- a/grammars/repositories/blocks/open-grammar.cson
+++ b/grammars/repositories/blocks/open-grammar.cson
@@ -10,7 +10,14 @@ patterns: [
   # An open block can be an anonymous container
   # --
   #
-  name: 'markup.raw.open.asciidoc'
+  name: 'markup.block.open.asciidoc'
   begin: '^(-{2})$'
+  beginCaptures:
+    1: name: 'constant.other.symbol.asciidoc'
+  patterns: [
+    include: '$self'
+  ]
   end: '^(\\1)$'
+  endCaptures:
+      1: name: 'constant.other.symbol.asciidoc'
 ]

--- a/spec/blocks/open-block-grammar-spec.coffee
+++ b/spec/blocks/open-block-grammar-spec.coffee
@@ -22,8 +22,8 @@ describe 'Open block', ->
         '''
       expect(tokens).toHaveLength 3
       expect(tokens[0]).toHaveLength 1
-      expect(tokens[0][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+      expect(tokens[0][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.open.asciidoc', 'constant.other.symbol.asciidoc']
       expect(tokens[1]).toHaveLength 1
-      expect(tokens[1][0]).toEqualJson value: 'foobar, foobar and foobar', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+      expect(tokens[1][0]).toEqualJson value: 'foobar, foobar and foobar', scopes: ['source.asciidoc', 'markup.block.open.asciidoc']
       expect(tokens[2]).toHaveLength 1
-      expect(tokens[2][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.raw.open.asciidoc']
+      expect(tokens[2][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.open.asciidoc', 'constant.other.symbol.asciidoc']

--- a/styles/asciidoc.atom-text-editor.less
+++ b/styles/asciidoc.atom-text-editor.less
@@ -103,6 +103,16 @@ atom-text-editor::shadow, :host {
           }
         }
       }
+
+      &.block {
+        &.sidebar,
+        &.passthrough,
+        &.literal,
+        &.front-matter,
+        &.example {
+          color: @syntax-text-color-unobtrusive;
+        }
+      }
     }
 
     .super {
@@ -113,10 +123,5 @@ atom-text-editor::shadow, :host {
       vertical-align: text-bottom;
       font-size: @font-size * .7;
     }
-
-    .block {
-      color: @syntax-text-color-unobtrusive;
-    }
-
   }
 }


### PR DESCRIPTION
## Description

Open block as Asciidoc code block.

## Syntax example

```adoc

Using Bundler::
+
--
Add the `jekyll-asciidoc` plugin gem to your [path]_Gemfile_:

[source,ruby]
----
group :jekyll_plugins do
  gem 'jekyll-asciidoc'
end
----

Then, run the Bundler command to install it:

 $ bundle install
--
```

## Screenshots

![capture du 2016-06-08 08-01-53](https://cloud.githubusercontent.com/assets/5674651/15884687/7ad0e8d2-2d52-11e6-8cbe-52ed086b6ca6.png)


Fix #154