### PR TITLE
feat: literal paragraph

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -37,6 +37,9 @@ patterns: [
     include: "#list"
   }
   {
+    include: "#literal-paragraph"
+  }
+  {
     include: "#inlines"
   }
   {
@@ -1219,6 +1222,14 @@ repository:
         name: "markup.block.literal.asciidoc"
         begin: "^(\\.{4,})$"
         end: "^(\\1)$"
+      }
+    ]
+  "literal-paragraph":
+    patterns: [
+      {
+        name: "markup.block.literal.asciidoc"
+        begin: "^\\p{Blank}+(.*)$"
+        end: "^\\p{Blank}*$"
       }
     ]
   "open-block":

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -24,6 +24,8 @@ patterns: [
 ,
   include: '#list'
 ,
+  include: '#literal-paragraph'
+,
   include: '#inlines'
 ,
   include: '#block-attribute'

--- a/grammars/repositories/blocks/literal-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/literal-paragraph-grammar.cson
@@ -1,0 +1,18 @@
+key: 'literal-paragraph'
+
+patterns: [
+
+  # Matches literal paragraph
+  #
+  # Examples
+  #
+  # Type the following command:
+  #
+  #  $ gem install asciidoctor
+  #
+  # Asciidoctor should now be installed on your machine.
+  #
+  name: 'markup.block.literal.asciidoc'
+  begin: '^\\p{Blank}+(.*)$'
+  end: '^\\p{Blank}*$'
+]

--- a/spec/blocks/admonition-block-grammar-spec.coffee
+++ b/spec/blocks/admonition-block-grammar-spec.coffee
@@ -12,10 +12,6 @@ describe 'Admonition block', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-# - Admonition block
-# - Admonition paragraph
-# - Admonition inline paragraph
-
   describe 'Should tokenizes when', ->
 
     it 'contains section title and bulleted list', ->
@@ -87,25 +83,24 @@ describe 'Admonition block', ->
       expect(tokens).toHaveLength 7
       numLine = 0
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: ' [IMPORTANT]', scopes: ['source.asciidoc']
-      numLine++
-      expect(tokens[numLine]).toHaveLength 2
-      expect(tokens[numLine][0]).toEqualJson value: '.', scopes: ['source.asciidoc']
-      expect(tokens[numLine][1]).toEqualJson value: 'Feeding the Werewolves', scopes: ['source.asciidoc', 'markup.heading.blocktitle.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: ' [IMPORTANT]', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: '.Feeding the Werewolves', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: 'While werewolves are hardy community members, keep in mind the following dietary concerns:', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: '...', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: 'While werewolves are hardy community members, keep in mind the following dietary concerns:', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: '...', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
-      expect(tokens[numLine][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']
+      expect(tokens[numLine][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
+      numLine++
+      expect(tokens[numLine]).toHaveLength 1
+      expect(tokens[numLine][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       numLine++
       expect(numLine).toBe 7

--- a/spec/blocks/admonition-inline-paragraph-grammar-spec.coffee
+++ b/spec/blocks/admonition-inline-paragraph-grammar-spec.coffee
@@ -44,9 +44,9 @@ describe 'Admonition inline paragraph', ->
         '''
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toHaveLength 1
-      expect(tokens[0][0]).toEqualJson value: ' [IMPORTANT]', scopes: ['source.asciidoc']
+      expect(tokens[0][0]).toEqualJson value: ' [IMPORTANT]', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[1]).toHaveLength 1
-      expect(tokens[1][0]).toEqualJson value: 'This is a important note.', scopes: ['source.asciidoc']
+      expect(tokens[1][0]).toEqualJson value: 'This is a important note.', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc']
       expect(tokens[3]).toHaveLength 1

--- a/spec/blocks/admonition-paragraph-grammar-spec.coffee
+++ b/spec/blocks/admonition-paragraph-grammar-spec.coffee
@@ -93,4 +93,4 @@ describe 'Admonition paragraph', ->
     it 'beginning with space', ->
       {tokens} = grammar.tokenizeLine ' CAUTION: Ensure that...'
       expect(tokens).toHaveLength 1
-      expect(tokens[0]).toEqualJson value: ' CAUTION: Ensure that...', scopes: ['source.asciidoc']
+      expect(tokens[0]).toEqualJson value: ' CAUTION: Ensure that...', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']

--- a/spec/blocks/literal-paragraph-grammar-spec.coffee
+++ b/spec/blocks/literal-paragraph-grammar-spec.coffee
@@ -1,0 +1,35 @@
+describe 'Literal paragraph', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes when', ->
+
+    it 'contains simple phrase', ->
+      tokens = grammar.tokenizeLines '''
+        Type the following command:
+
+         $ gem install asciidoctor
+
+        Asciidoctor should now be installed on your machine.
+        '''
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: 'Type the following command:', scopes: ['source.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '', scopes: ['source.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: ' $ gem install asciidoctor', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
+      expect(tokens[3]).toHaveLength 1
+      expect(tokens[3][0]).toEqualJson value: '', scopes: ['source.asciidoc']
+      expect(tokens[4]).toHaveLength 1
+      expect(tokens[4][0]).toEqualJson value: 'Asciidoctor should now be installed on your machine.', scopes: ['source.asciidoc']

--- a/spec/blocks/passthrough-paragraph-grammar-spec.coffee
+++ b/spec/blocks/passthrough-paragraph-grammar-spec.coffee
@@ -44,9 +44,9 @@ describe 'Passthrough paragraph', ->
         '''
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toHaveLength 1
-      expect(tokens[0][0]).toEqualJson value: ' [pass]', scopes: ['source.asciidoc']
+      expect(tokens[0][0]).toEqualJson value: ' [pass]', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[1]).toHaveLength 1
-      expect(tokens[1][0]).toEqualJson value: '<s>Could be struck through</s>', scopes: ['source.asciidoc']
+      expect(tokens[1][0]).toEqualJson value: '<s>Could be struck through</s>', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc']
       expect(tokens[3]).toHaveLength 1

--- a/spec/blocks/quote-paragraph-grammar-spec.coffee
+++ b/spec/blocks/quote-paragraph-grammar-spec.coffee
@@ -71,9 +71,9 @@ describe 'Quotes paragraph', ->
         '''
       expect(tokens).toHaveLength 4
       expect(tokens[0]).toHaveLength 1
-      expect(tokens[0][0]).toEqualJson value: ' [quote, Erwin Schrödinger, Sorry]', scopes: ['source.asciidoc']
+      expect(tokens[0][0]).toEqualJson value: ' [quote, Erwin Schrödinger, Sorry]', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[1]).toHaveLength 1
-      expect(tokens[1][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc']
+      expect(tokens[1][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc']
       expect(tokens[3]).toHaveLength 1

--- a/spec/blocks/source-paragraph-grammar-spec.coffee
+++ b/spec/blocks/source-paragraph-grammar-spec.coffee
@@ -46,9 +46,9 @@ describe 'Source paragraph', ->
                                       '''
       expect(tokens).toHaveLength 4 # Number of lines
       expect(tokens[0]).toHaveLength 1
-      expect(tokens[0][0]).toEqualJson value: ' [source,shell]', scopes: ['source.asciidoc']
+      expect(tokens[0][0]).toEqualJson value: ' [source,shell]', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[1]).toHaveLength 1
-      expect(tokens[1][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc']
+      expect(tokens[1][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '', scopes: ['source.asciidoc']
       expect(tokens[3]).toHaveLength 1

--- a/spec/partials/callout-list-item-grammar-spec.coffee
+++ b/spec/partials/callout-list-item-grammar-spec.coffee
@@ -1,4 +1,4 @@
-describe 'Should tokenizes callout list item when', ->
+describe 'Callout list item', ->
   grammar = null
 
   beforeEach ->
@@ -12,57 +12,61 @@ describe 'Should tokenizes callout list item when', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.asciidoc'
 
-  it 'contains simple callout', ->
-    {tokens} = grammar.tokenizeLine '<1> foobar'
-    expect(tokens).toHaveLength 5
-    expect(tokens[0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[4]).toEqualJson value: 'foobar', scopes: ['source.asciidoc', 'callout.asciidoc']
+  describe 'Should tokenizes when', ->
 
-  it 'contains callout mixed with inline element', ->
-    {tokens} = grammar.tokenizeLine '<1> *Grammars* _definition_'
-    expect(tokens).toHaveLength 11
-    expect(tokens[0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[5]).toEqualJson value: 'Grammars', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
-    expect(tokens[6]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[8]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
-    expect(tokens[9]).toEqualJson value: 'definition', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
-    expect(tokens[10]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+    it 'contains simple callout', ->
+      {tokens} = grammar.tokenizeLine '<1> foobar'
+      expect(tokens).toHaveLength 5
+      expect(tokens[0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[4]).toEqualJson value: 'foobar', scopes: ['source.asciidoc', 'callout.asciidoc']
 
-  it 'contains misplaced callout (invalid context)', ->
-    {tokens} = grammar.tokenizeLine '   <1> foobar'
-    expect(tokens).toHaveLength 1
-    expect(tokens[0]).toEqualJson value: '   <1> foobar', scopes: ['source.asciidoc']
+    it 'contains callout mixed with inline element', ->
+      {tokens} = grammar.tokenizeLine '<1> *Grammars* _definition_'
+      expect(tokens).toHaveLength 11
+      expect(tokens[0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[4]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[5]).toEqualJson value: 'Grammars', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
+      expect(tokens[6]).toEqualJson value: '*', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[7]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[8]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
+      expect(tokens[9]).toEqualJson value: 'definition', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc']
+      expect(tokens[10]).toEqualJson value: '_', scopes: ['source.asciidoc', 'callout.asciidoc', 'markup.emphasis.constrained.asciidoc', 'markup.italic.asciidoc', 'punctuation.definition.asciidoc']
 
-  it 'contains multiple callout', ->
-    tokens = grammar.tokenizeLines '''
-                                      <1> foobar
-                                      <2> fiibir
-                                      <3> feeber
-                                      '''
-    expect(tokens).toHaveLength 3
-    expect(tokens[0]).toHaveLength 5
-    expect(tokens[0][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[0][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[0][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[0][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[0][4]).toEqualJson value: 'foobar', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[1]).toHaveLength 5
-    expect(tokens[1][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[1][1]).toEqualJson value: '2', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[1][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[1][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[1][4]).toEqualJson value: 'fiibir', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[2]).toHaveLength 5
-    expect(tokens[2][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[2][1]).toEqualJson value: '3', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
-    expect(tokens[2][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
-    expect(tokens[2][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
-    expect(tokens[2][4]).toEqualJson value: 'feeber', scopes: ['source.asciidoc', 'callout.asciidoc']
+    it 'contains multiple callout', ->
+      tokens = grammar.tokenizeLines '''
+                                        <1> foobar
+                                        <2> fiibir
+                                        <3> feeber
+                                        '''
+      expect(tokens).toHaveLength 3
+      expect(tokens[0]).toHaveLength 5
+      expect(tokens[0][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[0][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[0][4]).toEqualJson value: 'foobar', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[1]).toHaveLength 5
+      expect(tokens[1][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1][1]).toEqualJson value: '2', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[1][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[1][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[1][4]).toEqualJson value: 'fiibir', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[2]).toHaveLength 5
+      expect(tokens[2][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[2][1]).toEqualJson value: '3', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
+      expect(tokens[2][2]).toEqualJson value: '>', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
+      expect(tokens[2][3]).toEqualJson value: ' ', scopes: ['source.asciidoc', 'callout.asciidoc']
+      expect(tokens[2][4]).toEqualJson value: 'feeber', scopes: ['source.asciidoc', 'callout.asciidoc']
+
+  describe 'Should not tokenizes when', ->
+
+    it 'contains misplaced callout', ->
+      {tokens} = grammar.tokenizeLine '   <1> foobar'
+      expect(tokens).toHaveLength 1
+      expect(tokens[0]).toEqualJson value: '   <1> foobar', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']


### PR DESCRIPTION
## Description

Support literal paragraph.

## Syntax example

```adoc
Type the following command:

 $ gem install asciidoctor

Asciidoctor should now be installed on your machine.

 $ gem install asciidoctor
$ gem install asciidoctor
$ gem install asciidoctor

foo
```

## Screenshots

![capture du 2016-06-08 21-04-39](https://cloud.githubusercontent.com/assets/5674651/15907256/a55da968-2dbc-11e6-8405-65a32622f584.png)

Fix #153