### PR TITLE
Enable embedded Kotlin language support

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -3169,6 +3169,81 @@ repository:
         end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
       }
       {
+        name: "markup.code.kotlin.asciidoc"
+        begin: "(?=(?>(?:^\\[(source)(?:,|#)\\p{Blank}*(?i:(kotlin|kts?))((?:,|#)[^\\]]+)*\\]$)))"
+        patterns: [
+          {
+            match: "^\\[(source)(?:,|#)\\p{Blank}*(?i:(kotlin|kts?))((?:,|#)([^,\\]]+))*\\]$"
+            captures:
+              "0":
+                name: "markup.heading.asciidoc"
+                patterns: [
+                  {
+                    include: "#block-attribute-inner"
+                  }
+                ]
+          }
+          {
+            include: "#inlines"
+          }
+          {
+            include: "#block-title"
+          }
+          {
+            comment: "listing block"
+            begin: "^(-{4,})\\s*$"
+            contentName: "source.embedded.kotlin"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
+              }
+              {
+                include: "source.kotlin"
+              }
+            ]
+            end: "^(\\1)$"
+          }
+          {
+            comment: "open block"
+            begin: "^(-{2})\\s*$"
+            contentName: "source.embedded.kotlin"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
+              }
+              {
+                include: "source.kotlin"
+              }
+            ]
+            end: "^(\\1)$"
+          }
+          {
+            comment: "literal block"
+            begin: "^(\\.{4})\\s*$"
+            contentName: "source.embedded.kotlin"
+            patterns: [
+              {
+                include: "#block-callout"
+              }
+              {
+                include: "#include-directive"
+              }
+              {
+                include: "source.kotlin"
+              }
+            ]
+            end: "^(\\1)$"
+          }
+        ]
+        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+      }
+      {
         name: "markup.code.css.less.asciidoc"
         begin: "(?=(?>(?:^\\[(source)(?:,|#)\\p{Blank}*(?i:(less))((?:,|#)[^\\]]+)*\\]$)))"
         patterns: [
@@ -5448,6 +5523,26 @@ repository:
           }
           {
             include: "source.julia"
+          }
+        ]
+        end: "^\\s*\\1\\s*$"
+        endCaptures:
+          "0":
+            name: "support.asciidoc"
+      }
+      {
+        name: "markup.code.kotlin.asciidoc"
+        begin: "^\\s*(`{3,})\\s*(?i:(kotlin|kts?))\\s*$"
+        beginCaptures:
+          "0":
+            name: "support.asciidoc"
+        contentName: "source.embedded.kotlin"
+        patterns: [
+          {
+            include: "#block-callout"
+          }
+          {
+            include: "source.kotlin"
           }
         ]
         end: "^\\s*\\1\\s*$"

--- a/grammars/repositories/languages.cson
+++ b/grammars/repositories/languages.cson
@@ -39,6 +39,8 @@
 ,
   pattern: 'julia', type: 'source', code: 'julia'
 ,
+  pattern: 'kotlin|kts?', type: 'source', code: 'kotlin'
+,
   pattern: 'less', type: 'source', code: 'css.less'
 ,
   pattern: 'make(file)?', type: 'source', code: 'makefile'

--- a/spec/fixtures/asciidoctor-lang.adoc
+++ b/spec/fixtures/asciidoctor-lang.adoc
@@ -55,6 +55,36 @@ public class HelloWorld {
 }
 ----
 
+== Kotlin (with plugin)
+
+```kotlin
+import java.util.*
+
+with(helloWorldTextView) {
+    text = "Hello World!"
+    visibility = View.VISIBLE
+}
+
+fun main(args: Array<String>) {
+    val name = if (args.size > 0) args[0] else "Publikum"
+    val zuschauer = Gast(name, title = Title.wertes)
+
+    println(zuschauer)
+    println("Hallo ${zuschauer.title} ${zuschauer.name}")
+}
+
+data class Gast(val name: String, var zeit: Date = Date(),
+                val title: Title?)
+enum class Title { Herr, Frau, wertes }
+```
+
+[source,kt]
+----
+open class HelloWorld {
+    inline fun <reified T : View> Activity.find(id: Int): T
+      = findViewById(id) as T
+}
+----
 
 == Markdown
 


### PR DESCRIPTION
## Description

This pull requests enables to embed/write Kotlin code within AsciiDoc files. To get it working one must have the plugin `atom-kotlin-language` with the patch mentioned below installed:

## Important Pre-Requisite

This feature requires https://github.com/alexmt/atom-kotlin-language/pull/7 to be merged, released and installed.

## Syntax example

    ```kotlin
    import java.util.*

    with(helloWorldTextView) {
        text = "Hello World!"
        visibility = View.VISIBLE
    }

    fun main(args: Array<String>) {
        val name = if (args.size > 0) args[0] else "Publikum"
        val zuschauer = Gast(name, title = Title.wertes)

        println(zuschauer)
        println("Hallo ${zuschauer.title} ${zuschauer.name}")
    }

    data class Gast(val name: String, var zeit: Date = Date(),
                    val title: Title?)
    enum class Title { Herr, Frau, wertes }
    ```

    [source,kt]
    ----
    open class HelloWorld {
        inline fun <reified T : View> Activity.find(id: Int): T
          = findViewById(id) as T
    }
    ----

## Screenshots

will render as_

![kotlin-support](https://cloud.githubusercontent.com/assets/588260/19593922/0e30adf2-9783-11e6-82c0-edc21ae1c7fa.png)