### PR TITLE
feat: support listing block.

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -63,6 +63,9 @@ repository:
         include: "#quote-paragraph"
       }
       {
+        include: "#listing-paragraph"
+      }
+      {
         include: "#source-paragraphs"
       }
       {
@@ -76,9 +79,6 @@ repository:
       }
       {
         include: "#literal-paragraph"
-      }
-      {
-        include: "#listing-paragraph"
       }
       {
         include: "#open-block"
@@ -1278,6 +1278,11 @@ repository:
           }
           {
             include: "#block-title"
+          }
+          {
+            comment: "listing block"
+            begin: "^(-{4,})\\s*$"
+            end: "^(\\1)$"
           }
           {
             comment: "open block"

--- a/grammars/repositories/asciidoc-grammar.cson
+++ b/grammars/repositories/asciidoc-grammar.cson
@@ -41,6 +41,8 @@ repository:
     ,
       include: '#quote-paragraph'
     ,
+      include: '#listing-paragraph'
+    ,
       include: '#source-paragraphs'
     ,
       include: '#passthrough-paragraph'
@@ -50,8 +52,6 @@ repository:
       include: '#sidebar-paragraph'
     ,
       include: '#literal-paragraph'
-    ,
-      include: '#listing-paragraph'
     ,
       include: '#open-block'
     ]

--- a/grammars/repositories/blocks/listing-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/listing-paragraph-grammar.cson
@@ -28,6 +28,10 @@ patterns: [
   ,
     include: '#block-title'
   ,
+    comment: 'listing block'
+    begin: '^(-{4,})\\s*$'
+    end: '^(\\1)$'
+  ,
     comment: 'open block'
     begin: '^(-{2})\\s*$'
     end: '^(\\1)$'

--- a/spec/blocks/listing-block-grammar-spec.coffee
+++ b/spec/blocks/listing-block-grammar-spec.coffee
@@ -1,0 +1,56 @@
+describe 'Listing block', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-asciidoc'
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName 'source.asciidoc'
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe 'source.asciidoc'
+
+  describe 'Should tokenizes when', ->
+
+    it 'contains simple phrase', ->
+      tokens = grammar.tokenizeLines '''
+        [listing]
+        ----
+        A multi-line listing.
+        ----
+        '''
+
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toHaveLength 3
+      expect(tokens[0][0]).toEqualJson value: '[', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+      expect(tokens[0][1]).toEqualJson value: 'listing', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc', 'markup.meta.attribute-list.asciidoc', 'entity.name.function.asciidoc']
+      expect(tokens[0][2]).toEqualJson value: ']', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'A multi-line listing.', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
+
+  describe 'Should not tokenizes when', ->
+
+    it 'beginning with space', ->
+      tokens = grammar.tokenizeLines '''
+         [listing]
+        ----
+        A multi-line listing.
+        ----
+        '''
+
+      expect(tokens).toHaveLength 4
+      expect(tokens[0]).toHaveLength 1
+      expect(tokens[0][0]).toEqualJson value: ' [listing]', scopes: ['source.asciidoc']
+      expect(tokens[1]).toHaveLength 1
+      expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.raw.asciidoc', 'support.asciidoc']
+      expect(tokens[2]).toHaveLength 1
+      expect(tokens[2][0]).toEqualJson value: 'A multi-line listing.', scopes: ['source.asciidoc', 'markup.raw.asciidoc']
+      expect(tokens[3]).toHaveLength 1
+      expect(tokens[3][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.raw.asciidoc', 'support.asciidoc']


### PR DESCRIPTION
## Description

- support listing block

## Syntax example

```adoc
== Heading

== Heading

This para is highlighted normally.

[listing]
----
This is a listing.
----

Everything after here is good.
```

## Screenshots

![capture du 2017-03-16 21-25-55](https://cloud.githubusercontent.com/assets/5674651/24017156/2c65b842-0a8f-11e7-9f62-4069c50de150.png)

Fix #161 