### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/language-asciidoc.cson
+++ b/grammars/language-asciidoc.cson
@@ -1136,7 +1136,7 @@ repository:
             end: "(?<=\\1)"
           }
         ]
-        end: "((?<=--|====)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|====)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.admonition.asciidoc"
@@ -1188,7 +1188,7 @@ repository:
             include: "#inlines"
           }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--)$|^\\p{Blank}*$)"
       }
     ]
   "example-paragraph":
@@ -1234,7 +1234,7 @@ repository:
             include: "#inlines"
           }
         ]
-        end: "((?<=--|====)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|====)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.block.example.asciidoc"
@@ -1293,7 +1293,7 @@ repository:
             include: "#inlines"
           }
         ]
-        end: "((?<=--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--)$|^\\p{Blank}*$)"
       }
     ]
   "literal-paragraph":
@@ -1329,7 +1329,7 @@ repository:
             include: "#inlines"
           }
         ]
-        end: "((?<=--|\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.block.literal.asciidoc"
@@ -1397,7 +1397,7 @@ repository:
             end: "(?<=\\1)"
           }
         ]
-        end: "((?<=--|\\+\\+)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\+\\+)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.block.passthrough.asciidoc"
@@ -1472,7 +1472,7 @@ repository:
             end: "(?<=\\1)$"
           }
         ]
-        end: "((?<=____|\"\"|--)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=____|\"\"|--)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.italic.quotes.asciidoc"
@@ -1544,7 +1544,7 @@ repository:
             include: "#inlines"
           }
         ]
-        end: "((?<=--|\\*\\*\\*\\*)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\*\\*\\*\\*)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.block.sidebar.asciidoc"
@@ -1747,7 +1747,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.clojure.asciidoc"
@@ -1822,7 +1822,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.coffee.asciidoc"
@@ -1897,7 +1897,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.cpp.asciidoc"
@@ -1972,7 +1972,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.asciidoc"
@@ -2047,7 +2047,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.cs.asciidoc"
@@ -2122,7 +2122,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.diff.asciidoc"
@@ -2197,7 +2197,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.dockerfile.asciidoc"
@@ -2272,7 +2272,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.elixir.asciidoc"
@@ -2347,7 +2347,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.elm.asciidoc"
@@ -2422,7 +2422,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.erlang.asciidoc"
@@ -2497,7 +2497,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.go.asciidoc"
@@ -2572,7 +2572,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.groovy.asciidoc"
@@ -2647,7 +2647,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.haskell.asciidoc"
@@ -2722,7 +2722,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.basic.asciidoc"
@@ -2797,7 +2797,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.java.asciidoc"
@@ -2872,7 +2872,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.js.asciidoc"
@@ -2947,7 +2947,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.json.asciidoc"
@@ -3022,7 +3022,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.js.jsx.asciidoc"
@@ -3097,7 +3097,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.julia.asciidoc"
@@ -3172,7 +3172,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.kotlin.asciidoc"
@@ -3247,7 +3247,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.less.asciidoc"
@@ -3322,7 +3322,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.makefile.asciidoc"
@@ -3397,7 +3397,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.gfm.asciidoc"
@@ -3472,7 +3472,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.mustache.asciidoc"
@@ -3547,7 +3547,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.objc.asciidoc"
@@ -3622,7 +3622,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ocaml.asciidoc"
@@ -3697,7 +3697,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.perl.asciidoc"
@@ -3772,7 +3772,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.perl6.asciidoc"
@@ -3847,7 +3847,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.html.php.asciidoc"
@@ -3922,7 +3922,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.asciidoc.properties.asciidoc"
@@ -3997,7 +3997,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.python.asciidoc"
@@ -4072,7 +4072,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.r.asciidoc"
@@ -4147,7 +4147,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ruby.asciidoc"
@@ -4222,7 +4222,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.rust.asciidoc"
@@ -4297,7 +4297,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.sass.asciidoc"
@@ -4372,7 +4372,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.scala.asciidoc"
@@ -4447,7 +4447,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.css.scss.asciidoc"
@@ -4522,7 +4522,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.shell.asciidoc"
@@ -4597,7 +4597,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.sql.asciidoc"
@@ -4672,7 +4672,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.swift.asciidoc"
@@ -4747,7 +4747,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.toml.asciidoc"
@@ -4822,7 +4822,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.ts.asciidoc"
@@ -4897,7 +4897,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.xml.asciidoc"
@@ -4972,7 +4972,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.code.yaml.asciidoc"
@@ -5047,7 +5047,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         begin: "(?=(?>(?:^\\[(source)((?:,|#)[^\\]]+)*\\]$)))"
@@ -5112,7 +5112,7 @@ repository:
             end: "^(\\1)$"
           }
         ]
-        end: "((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)"
+        end: "((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)"
       }
       {
         name: "markup.raw.asciidoc"

--- a/grammars/repositories/blocks/admonition-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/admonition-paragraph-grammar.cson
@@ -57,7 +57,7 @@ patterns: [
     ]
     end: '(?<=\\1)'
   ]
-  end: '((?<=--|====)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--|====)$|^\\p{Blank}*$)'
 ,
   # Matches admonition blocks
   #

--- a/grammars/repositories/blocks/comment-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/comment-paragraph-grammar.cson
@@ -39,5 +39,5 @@ patterns: [
   ,
     include: '#inlines'
   ]
-  end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--)$|^\\p{Blank}*$)'
 ]

--- a/grammars/repositories/blocks/example-grammar.cson
+++ b/grammars/repositories/blocks/example-grammar.cson
@@ -51,7 +51,7 @@ patterns: [
   ,
     include: '#inlines'
   ]
-  end: '((?<=--|====)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--|====)$|^\\p{Blank}*$)'
 ,
   # Matches example block
   #

--- a/grammars/repositories/blocks/listing-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/listing-paragraph-grammar.cson
@@ -38,5 +38,5 @@ patterns: [
   ,
     include: '#inlines'
   ]
-  end: '((?<=--)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--)$|^\\p{Blank}*$)'
 ]

--- a/grammars/repositories/blocks/literal-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/literal-paragraph-grammar.cson
@@ -45,7 +45,7 @@ patterns: [
   ,
     include: '#inlines'
   ]
-  end: '((?<=--|\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--|\\.\\.)$|^\\p{Blank}*$)'
 ,
   # Matches literal block
   #

--- a/grammars/repositories/blocks/passthrough-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/passthrough-paragraph-grammar.cson
@@ -52,7 +52,7 @@ patterns: [
     ]
     end: '(?<=\\1)'
   ]
-  end: '((?<=--|\\+\\+)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--|\\+\\+)$|^\\p{Blank}*$)'
 ,
   # Matches passthrough block
   #

--- a/grammars/repositories/blocks/quote-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/quote-paragraph-grammar.cson
@@ -72,7 +72,7 @@ patterns: [
     ]
     end: '(?<=\\1)$'
   ]
-  end: '((?<=____|""|--)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=____|""|--)$|^\\p{Blank}*$)'
 ,
   # Matches air quotes.
   #

--- a/grammars/repositories/blocks/sidebar-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/sidebar-paragraph-grammar.cson
@@ -51,7 +51,7 @@ patterns: [
   ,
     include: '#inlines'
   ]
-  end: '((?<=--|\\*\\*\\*\\*)[\\r\\n]+$|^\\p{Blank}*$)'
+  end: '((?<=--|\\*\\*\\*\\*)$|^\\p{Blank}*$)'
 ,
   # Matches sidebar block
   #

--- a/lib/code-block-generator.coffee
+++ b/lib/code-block-generator.coffee
@@ -55,7 +55,7 @@ module.exports =
         ]
         end: '^(\\1)$'
       ]
-      end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+      end: '((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)'
 
     # add generic block
     codeBlocks.push
@@ -103,7 +103,7 @@ module.exports =
         ]
         end: '^(\\1)$'
       ]
-      end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+      end: '((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)'
 
     # add listing block
     codeBlocks.push

--- a/spec/blocks/admonition-block-grammar-spec.coffee
+++ b/spec/blocks/admonition-block-grammar-spec.coffee
@@ -63,9 +63,8 @@ describe 'Admonition block', ->
       expect(tokens[numLine][0]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.admonition.asciidoc', 'markup.list.asciidoc', 'markup.list.bullet.asciidoc']
       expect(tokens[numLine][1]).toEqualJson value: ' Celery makes them sad.', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
       numLine++
-      expect(tokens[numLine]).toHaveLength 2
+      expect(tokens[numLine]).toHaveLength 1
       expect(tokens[numLine][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
-      expect(tokens[numLine][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.admonition.asciidoc']
       numLine++
       expect(tokens[numLine]).toHaveLength 1
       expect(tokens[numLine][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/comment-open-block-grammar-spec.coffee
+++ b/spec/blocks/comment-open-block-grammar-spec.coffee
@@ -40,8 +40,7 @@ describe 'Comment open block', ->
       expect(tokens[4][0]).toEqualJson value: '', scopes: ['source.asciidoc', 'comment.block.asciidoc']
       expect(tokens[5]).toHaveLength 1
       expect(tokens[5][0]).toEqualJson value: 'an open block comment.', scopes: ['source.asciidoc', 'comment.block.asciidoc']
-      expect(tokens[6]).toHaveLength 2
+      expect(tokens[6]).toHaveLength 1
       expect(tokens[6][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'comment.block.asciidoc']
-      expect(tokens[6][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'comment.block.asciidoc']
       expect(tokens[7]).toHaveLength 1
       expect(tokens[7][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/example-open-block-grammar-spec.coffee
+++ b/spec/blocks/example-open-block-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Example open block', ->
       expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'A multi-line example.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/example-paragraph-grammar-spec.coffee
+++ b/spec/blocks/example-paragraph-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Example paragraph', ->
       expect(tokens[1][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'A multi-line example.', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '====', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.example.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/listing-block-grammar-spec.coffee
+++ b/spec/blocks/listing-block-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Listing block', ->
       expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'A multi-line listing.', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/listing-open-block-grammar-spec.coffee
+++ b/spec/blocks/listing-open-block-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Listing open block', ->
       expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'A multi-line listing.', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.listing.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/literal-open-block-grammar-spec.coffee
+++ b/spec/blocks/literal-open-block-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Literal open block', ->
       expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'Daleks EXTERMINATE in monospace!', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/literal-paragraph-grammar-spec.coffee
+++ b/spec/blocks/literal-paragraph-grammar-spec.coffee
@@ -31,9 +31,8 @@ describe 'Literal paragraph', ->
       expect(tokens[1][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'Daleks EXTERMINATE in monospace!', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.literal.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/passthrough-block-grammar-spec.coffee
+++ b/spec/blocks/passthrough-block-grammar-spec.coffee
@@ -48,8 +48,7 @@ describe 'Passthrough block', ->
       expect(tokens[1][0]).toEqualJson value: '++++', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '<s>Could be struck through</s>', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '++++', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
       expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/passthrough-open-block-grammar-spec.coffee
+++ b/spec/blocks/passthrough-open-block-grammar-spec.coffee
@@ -31,8 +31,7 @@ describe 'Passthrough open block', ->
       expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: '<s>Could be struck through</s>', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.passthrough.asciidoc']
       expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/quote-air-block-grammar-spec.coffee
+++ b/spec/blocks/quote-air-block-grammar-spec.coffee
@@ -35,9 +35,8 @@ describe 'Air quotes', ->
       expect(tokens[1][0]).toEqualJson value: '""', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '""', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']
 

--- a/spec/blocks/quote-block-grammar-spec.coffee
+++ b/spec/blocks/quote-block-grammar-spec.coffee
@@ -35,8 +35,7 @@ describe 'Quotes block', ->
       expect(tokens[1][0]).toEqualJson value: '____', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '____', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/quote-open-block-grammar-spec.coffee
+++ b/spec/blocks/quote-open-block-grammar-spec.coffee
@@ -35,8 +35,7 @@ describe 'Quotes open block', ->
       expect(tokens[1][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'I don\'t like it, and I\'m sorry I ever had anything to do with it.', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.italic.quotes.asciidoc']
       expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: 'foobar', scopes: ['source.asciidoc']

--- a/spec/blocks/sidebar-open-block-grammar-spec.coffee
+++ b/spec/blocks/sidebar-open-block-grammar-spec.coffee
@@ -35,9 +35,8 @@ describe 'Sidebar open block', ->
       expect(tokens[2][2]).toEqualJson value: 'sidebar', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
       expect(tokens[2][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[2][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/sidebar-paragraph-grammar-spec.coffee
+++ b/spec/blocks/sidebar-paragraph-grammar-spec.coffee
@@ -35,9 +35,8 @@ describe 'Sidebar paragraph', ->
       expect(tokens[2][2]).toEqualJson value: 'sidebar', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc']
       expect(tokens[2][3]).toEqualJson value: '*', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc', 'markup.strong.constrained.asciidoc', 'markup.bold.asciidoc', 'punctuation.definition.asciidoc']
       expect(tokens[2][4]).toEqualJson value: '.', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '****', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.block.sidebar.asciidoc']
 
   describe 'Should not tokenizes when', ->
 

--- a/spec/blocks/source-block-grammar-spec.coffee
+++ b/spec/blocks/source-block-grammar-spec.coffee
@@ -37,9 +37,8 @@ describe 'Source block', ->
       expect(tokens[2][0]).toEqualJson value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
       expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
-      expect(tokens[4]).toHaveLength 2
+      expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
-      expect(tokens[4][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
       expect(tokens[5]).toHaveLength 11
       expect(tokens[5][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
       expect(tokens[5][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
@@ -87,6 +86,5 @@ describe 'Source block', ->
       expect(tokens[1][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'System.out.println("Hello *strong* text").', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'source.embedded.java']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']

--- a/spec/blocks/source-literal-grammar-spec.coffee
+++ b/spec/blocks/source-literal-grammar-spec.coffee
@@ -37,9 +37,8 @@ describe 'Source literal', ->
       expect(tokens[2][0]).toEqualJson value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
       expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
-      expect(tokens[4]).toHaveLength 2
+      expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
-      expect(tokens[4][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
       expect(tokens[5]).toHaveLength 11
       expect(tokens[5][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
       expect(tokens[5][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']
@@ -87,6 +86,5 @@ describe 'Source literal', ->
       expect(tokens[1][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
       expect(tokens[2]).toHaveLength 1
       expect(tokens[2][0]).toEqualJson value: 'System.out.println("Hello *strong* text").', scopes: ['source.asciidoc', 'markup.code.java.asciidoc', 'source.embedded.java']
-      expect(tokens[3]).toHaveLength 2
+      expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: '....', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']
-      expect(tokens[3][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.java.asciidoc']

--- a/spec/blocks/source-open-block-grammar-spec.coffee
+++ b/spec/blocks/source-open-block-grammar-spec.coffee
@@ -37,9 +37,8 @@ describe 'Source open block', ->
       expect(tokens[2][0]).toEqualJson value: 'ls -l', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
       expect(tokens[3]).toHaveLength 1
       expect(tokens[3][0]).toEqualJson value: 'cd ..', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc', 'source.embedded.shell']
-      expect(tokens[4]).toHaveLength 2
+      expect(tokens[4]).toHaveLength 1
       expect(tokens[4][0]).toEqualJson value: '--', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
-      expect(tokens[4][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.shell.asciidoc']
       expect(tokens[5]).toHaveLength 11
       expect(tokens[5][0]).toEqualJson value: '<', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.other.symbol.asciidoc']
       expect(tokens[5][1]).toEqualJson value: '1', scopes: ['source.asciidoc', 'callout.asciidoc', 'constant.numeric.asciidoc']

--- a/spec/code-block-generator-spec.coffee
+++ b/spec/code-block-generator-spec.coffee
@@ -53,7 +53,7 @@ describe 'Code block generator', ->
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)'
 
     it 'should generate listing block', ->
       languages = []
@@ -131,7 +131,7 @@ describe 'Code block generator', ->
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)'
 
     it 'should generate C++ code block', ->
       languages = [
@@ -191,7 +191,7 @@ describe 'Code block generator', ->
           ]
           end: '^(\\1)$'
         ]
-        end: '((?<=--|\\.\\.\\.\\.)[\\r\\n]+$|^\\p{Blank}*$)'
+        end: '((?<=--|\\.\\.\\.\\.)$|^\\p{Blank}*$)'
 
   describe 'with Markdown syntax', ->
 

--- a/spec/partials/block-callout-grammar-spec.coffee
+++ b/spec/partials/block-callout-grammar-spec.coffee
@@ -53,6 +53,5 @@ describe 'Should tokenizes callout in code block when', ->
     expect(tokens[5][4]).toEqualJson value: '>', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js', 'callout.source.code.asciidoc', 'constant.other.symbol.asciidoc']
     expect(tokens[6]).toHaveLength 1
     expect(tokens[6][0]).toEqualJson value: '}).listen(1337, \'127.0.0.1\');', scopes: ['source.asciidoc', 'markup.code.js.asciidoc', 'source.embedded.js']
-    expect(tokens[7]).toHaveLength 2
+    expect(tokens[7]).toHaveLength 1
     expect(tokens[7][0]).toEqualJson value: '----', scopes: ['source.asciidoc', 'markup.code.js.asciidoc']
-    expect(tokens[7][1]).toEqualJson value: '', scopes: ['source.asciidoc', 'markup.code.js.asciidoc']


### PR DESCRIPTION
## Description

This PR removes the `[\\r\\n]+` requirement present in some end patterns.  This regex wasn't really doing anything important in the first place (all it was contributing was a zero-width match at the end of the line).  In addition, due to atom/first-mate#100, newlines are no longer added to the last line of the file, meaning that rules containing `[\\r\\n]+` would fail to match on the last line.  Therefore, this change is simply a backwards-compatible change to ensure that language-asciidoc continues working as before on Atom 1.22+.

I hope I did the whole grammar generation correctly!

/cc @Ingramz

Refs atom/atom#15729