### PR TITLE
repair regex in #quote-paragraph macro

### DIFF
--- a/grammars/repositories/blocks/quote-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/quote-paragraph-grammar.cson
@@ -32,9 +32,9 @@ patterns: [
   #   --
   #
   name: 'markup.italic.quotes.asciidoc'
-  begin: '(?=(?>(?:^\\[(quote|verse)((?:(?:,|#|\\.|%)([^,]+?))*)\\]$)))'
+  begin: '(?=(?>(?:^\\[(quote|verse)(?:(?:,|#|\\.|%)([^,]+?))*\\]$)))'
   patterns: [
-    match: '^\\[(quote|verse)((?:(?:,|#|\\.|%)([^,]+?))*)\\]$'
+    match: '^\\[(quote|verse)(?:(?:,|#|\\.|%)([^,]+?))*\\]$'
     captures:
       0:
         patterns: [

--- a/grammars/repositories/blocks/quote-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/quote-paragraph-grammar.cson
@@ -32,9 +32,9 @@ patterns: [
   #   --
   #
   name: 'markup.italic.quotes.asciidoc'
-  begin: '(?=(?>(?:^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$)))'
+  begin: '(?=(?>(?:^\\[(quote|verse)((?:(?:,|#|\\.|%)([^,]+?))*)\\]$)))'
   patterns: [
-    match: '^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$'
+    match: '^\\[(quote|verse)((?:(?:,|#|\\.|%)([^,]+?))*)\\]$'
     captures:
       0:
         patterns: [

--- a/grammars/repositories/blocks/quote-paragraph-grammar.cson
+++ b/grammars/repositories/blocks/quote-paragraph-grammar.cson
@@ -32,9 +32,9 @@ patterns: [
   #   --
   #
   name: 'markup.italic.quotes.asciidoc'
-  begin: '(?=(?>(?:^\\[(quote|verse)(?:(?:,|#|\\.|%)([^,]+?))*\\]$)))'
+  begin: '(?=(?>(?:^\\[(quote|verse)(?:(?:,|#|\\.|%)(?:[^,\\]]|\\](?=[ \\t]*\\S))+)*\\]$)))'
   patterns: [
-    match: '^\\[(quote|verse)(?:(?:,|#|\\.|%)([^,]+?))*\\]$'
+    match: '^\\[(quote|verse)(?:(?:,|#|\\.|%)(?:[^,\\]]|\\](?=[ \\t]*\\S))+)*\\]$'
     captures:
       0:
         patterns: [

--- a/grammars/repositories/partials/block-attribute-inner-grammar.cson
+++ b/grammars/repositories/partials/block-attribute-inner-grammar.cson
@@ -19,7 +19,7 @@ patterns: [
 ,
   comment: 'attributes'
   name: 'markup.meta.attribute-list.asciidoc'
-  match: '(?<=\\{|,|.|#|"|\'|%)([^\\],.#%]+)'
+  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[^\',.#%]*\'))+)'
   captures:
     0:
       patterns: [

--- a/grammars/repositories/partials/block-attribute-inner-grammar.cson
+++ b/grammars/repositories/partials/block-attribute-inner-grammar.cson
@@ -19,7 +19,7 @@ patterns: [
 ,
   comment: 'attributes'
   name: 'markup.meta.attribute-list.asciidoc'
-  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[^\',.#%]*\'))+)'
+  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[ \\t\\f]*\\S))+)'
   captures:
     0:
       patterns: [

--- a/grammars/repositories/partials/block-attribute-inner-grammar.cson
+++ b/grammars/repositories/partials/block-attribute-inner-grammar.cson
@@ -19,7 +19,7 @@ patterns: [
 ,
   comment: 'attributes'
   name: 'markup.meta.attribute-list.asciidoc'
-  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[ \\t]*\\S))+)'
+  match: '(?<=\\{|,|\\.|#|"|\'|%)(?:[^\\],.#%]|\\](?=[ \\t]*\\S))+'
   captures:
     0:
       patterns: [

--- a/grammars/repositories/partials/block-attribute-inner-grammar.cson
+++ b/grammars/repositories/partials/block-attribute-inner-grammar.cson
@@ -19,7 +19,7 @@ patterns: [
 ,
   comment: 'attributes'
   name: 'markup.meta.attribute-list.asciidoc'
-  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[ \\t\\f]*\\S))+)'
+  match: '(?<=\\{|,|\\.|#|"|\'|%)((?:[^\\],.#%]|\\](?=[ \\t]*\\S))+)'
   captures:
     0:
       patterns: [


### PR DESCRIPTION
## Description

The regex for the quote-paragraph rule is not as robust as it could be -- and also, either not as efficient as it could be, or else (if you're REALLY wanting to refer to captured groups) capturing one group incorrectly.

Here's the regex-segment that is in common between the regexes on lines 35 and 37 of the file ("quote-paragraph-grammar.cson"):

`^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$`

The robustness problem is that as it stands, the regex will not match any block-attribute-list that contains, itself, an inline macro -- such as a URL macro (see screen-shot) or a bibliographic-citation macro (see the below syntax example). And no, it doesn't help, if you escape the closing bracket of the inline macro.

This problem is located in the character-group in the regex: In order to get the character-class not to run away with the rest of the quote-block, there was included in it the closing ']' of the block-attribute-list; but one could have achieved the same thing better by making the quantifier "[lazy](https://www.regular-expressions.info/repeat.html#greedy)":

instead of 
    `([^,\\]]+)`
one could just write
    `([^,]+?)`

With that change, the regex matches also these inline-macro-containing quote-block-attribute-lists (see screen shots).

As for the other problem: If you **don't** really need to capture any groups (i.e., you're not gong to refer to them, as is not done inside the present macro), then the regex will run more efficiently if the capturing groups are made non-capturing groups.

On the other hand, if we **are** wanting to capture those groups, then we need to fix the second capturing group:

`((?:,|#|\\.|%)([^,\\]]+))*`

Putting a quantifier on a capturing group, like this, leads to the problem which "Regex Buddy" explains thus:

> You repeated the capturing group itself.  The group will capture only the last iteration.  Put a capturing group around the repeated group to capture all iterations. «*»
> Or, if you don’t want to capture anything, replace the capturing group with a non-capturing group to make your regex more efficient.

I took the first, safer route for this problem, in my code-fix, in case we do want to capture:

`((?:(?:,|#|\\.|%)([^,]+?))*)`

If capturing is superfluous, though, then we can just drop the outermost (the capturing) group -- like so:

`(?:(?:,|#|\\.|%)([^,]+?))*`


## Syntax example

```asciidoc
[quote, Louis Berkhof, 'cite:[ Berkhof1975, prefix= "see ", page= 29]']
____
[.nonsuccessor-para]
The study of the History of Dogma as a separate discipline is of a comparatively recent date. ... Since the Church of Rome proceeded on the assumption, and still maintains the position, that dogma is unchangeable, it may be said that the Reformation by breaking with that view opened the way for a critical treatment of the history of dogma. Moreover, [Protestantism] was a movement which, in its very nature, was well calculated to furnish a special incentive for such a study. It raised many questions respecting the nature of the Church and her teachings, and sought to answer these not only in the light of Scripture but also with an appeal to the Fathers of the early Church, thus furnishing a direct and powerful motive for a [critical] historical study of dogma.
____
```

## Screenshots

![Example-1_Screen-with-OLD-regex](https://user-images.githubusercontent.com/26470458/147699619-230cabce-abf2-495c-837c-2c19cc057a3e.png)
![Example-1_Screen-with-NEW-regex](https://user-images.githubusercontent.com/26470458/147699620-d99c9f74-e22b-4825-b4b5-3f02689db25d.png)

